### PR TITLE
macOS-Notification-Hooks für Claude Code + Workflow-Doku

### DIFF
--- a/claude/.claude/hooks/macos-notify.sh
+++ b/claude/.claude/hooks/macos-notify.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# macos-notify.sh — surface Claude Code Notification/Stop events as macOS
+# banners, replacing supacode's agent presence badges. No-op inside supacode
+# (its own hooks own presence there) so notifications never fire twice.
+set -euo pipefail
+
+# Skip inside supacode. SUPACODE_SOCKET_PATH is injected by its shell
+# integration; __CFBundleIdentifier is set by macOS at process start.
+if [ -n "${SUPACODE_SOCKET_PATH:-}" ]; then exit 0; fi
+if [ "${__CFBundleIdentifier:-}" = "app.supabit.supacode" ]; then exit 0; fi
+
+payload=$(cat)
+event=$(printf '%s' "$payload" | /usr/bin/jq -r '.hook_event_name // empty')
+cwd=$(printf '%s' "$payload" | /usr/bin/jq -r '.cwd // empty')
+dir=$(basename "${cwd:-$PWD}")
+
+case "$event" in
+Notification)
+	msg=$(printf '%s' "$payload" | /usr/bin/jq -r '.message // "Notification"')
+	;;
+Stop)
+	msg="Done: $dir"
+	;;
+*)
+	exit 0
+	;;
+esac
+
+# Include the zellij session name when running inside zellij.
+title="Claude Code${ZELLIJ_SESSION_NAME:+ · $ZELLIJ_SESSION_NAME}"
+
+# Pass text as argv, never interpolated into the AppleScript source, so payload
+# content cannot break out of the string.
+osascript - "$title" "$msg" <<'APPLESCRIPT' || true
+on run argv
+	display notification (item 2 of argv) with title (item 1 of argv) sound name "Glass"
+end run
+APPLESCRIPT

--- a/claude/.stow-local-ignore
+++ b/claude/.stow-local-ignore
@@ -1,0 +1,14 @@
+# A custom stow ignore list REPLACES stow's built-in defaults, so the important
+# defaults are repeated here (otherwise README.md would be stowed into ~).
+\.git
+\.gitignore
+.+~
+\#.*\#
+^/README.*
+^/LICENSE.*
+^/COPYING
+
+# settings.json is rewritten live by Claude Code / supacode (format + agent
+# integration hooks), so it is app-managed and must not be a stow symlink.
+# Own hooks (e.g. macos-notify) are merged into the live file, not stowed.
+^/\.claude/settings\.json$

--- a/docs/zellij-workflow.md
+++ b/docs/zellij-workflow.md
@@ -1,0 +1,104 @@
+# Zellij-Worktree-Workflow (Supacode-Ersatz)
+
+Dieser Workflow bildet die Supacode-Orchestrierungsebene in Ghostty + Zellij nach.
+Grundmodell bleibt **ein git-Worktree = eine Zellij-Session**. Supacode selbst
+(Package + Hooks) bleibt koexistent installiert; die hier beschriebenen Bausteine
+sind außerhalb von Supacode aktiv und innerhalb inaktiv.
+
+| Supacode-Feature | Ersatz |
+|---|---|
+| ⌘N neuer Worktree, Archive | `wt new` / `wt done` |
+| ⌘P / ⌃1-⌃0 Worktree-Switching | `zj-sessionizer` auf `Ctrl f` |
+| GitHub-Sidebar (PRs/Checks) | gh-dash-Pane im `dev`-Layout + Pane-Mode `g` |
+| Statusbar | compact-bar (Default) bzw. optional zjstatus |
+| Agent-Badges/Sounds | Claude-Code-Hook `macos-notify.sh` |
+| Session-Persistenz (zmx) | Zellijs `session_serialization` (bereits aktiv) |
+
+## Worktrees: `wt`
+
+```sh
+wt new <branch> [repo-pfad]   # Worktree von origin/main + Session öffnen
+wt done                       # Worktree, Branch und Session aufräumen
+wt list                       # Worktrees + Session-Status
+```
+
+- Worktree-Pfad: `~/worktrees/<repo>/<branch>`, Session-Name: `<repo>-<branch>`
+  (Sonderzeichen im Branch werden zu `-`).
+- Ohne `repo-pfad` wird das Repo des aktuellen Verzeichnisses genommen.
+- `wt done` bricht bei uncommitteten Änderungen ab und löscht die eigene Session
+  zuletzt (kappt dabei die laufende Shell — gewollt, wie Supacodes Archive).
+
+## Switching: `Ctrl f`
+
+`Ctrl f` öffnet den Sessionizer (fzf) in einer Floating Pane: Auswahl aus
+laufenden Sessions, `~/repos/*/*` und `~/worktrees/*/*`. Innerhalb von Zellij
+wird über das `zellij-switch`-Plugin gewechselt (nested `attach` ist unmöglich),
+außerhalb via `attach --create`.
+
+## PR-Status: gh-dash
+
+- Das `dev`-Layout (Default) hat auf dem ersten Tab eine permanente gh-dash-Pane
+  (25% rechts). Neue Tabs bleiben ohne Sidebar.
+- In anderen Tabs: Pane-Mode (`Ctrl p`) dann `g` öffnet gh-dash on-demand rechts.
+- gh-dash ist cwd-unabhängig; die angezeigten Queries stehen in
+  `~/.config/gh-dash/config.yml` (Default: `is:open involves:@me`).
+- Nach einer wiederhergestellten Session (Serialization) steht die gh-dash-Pane
+  suspendiert da („Press Enter to re-run") — ein Tastendruck startet sie neu.
+
+## Statusbar: zjstatus (optional)
+
+Standard ist die `compact-bar` (Layout `dev`). Optional gibt es die Variante
+`dev-zjstatus` (Layout `dev-zjstatus.kdl`) mit zjstatus: Mode, Session, Tabs,
+PR-State des fokussierten Panes und Uhrzeit.
+
+Umschalten / Rückbau über `default_layout` in `config.kdl`:
+
+- `default_layout "dev-zjstatus"` — zjstatus-Bar + Sidebar
+- `default_layout "dev"` — compact-bar + Sidebar
+- `default_layout "compact"` — Stock, keine Sidebar
+
+Der zjstatus-Teil liegt bewusst in einer eigenen Layout-Datei, damit ein
+`git revert` des zjstatus-Commits (oder ein `default_layout`-Flip) die
+Sidebar-Konfiguration unangetastet lässt.
+
+## Notifications: `macos-notify.sh`
+
+Der Hook feuert bei den Claude-Code-Events `Notification` (Agent wartet auf
+Input) und `Stop` (Agent fertig) ein macOS-Banner mit Sound; der Zellij-Session-
+Name steht im Titel. Innerhalb von Supacode ist der Hook ein No-op
+(`SUPACODE_SOCKET_PATH` / Bundle-ID), damit keine doppelten Benachrichtigungen
+entstehen.
+
+Das Skript selbst kommt über den `hooks`-Symlink automatisch mit `task setup`.
+Die **Verdrahtung** muss dagegen von Hand in die app-verwaltete
+`~/.claude/settings.json` (siehe unten) — einmal pro Maschine, idempotent:
+
+```sh
+tmp=$(mktemp)
+jq '
+  (.hooks.Notification //= []) | (.hooks.Stop //= []) |
+  .hooks.Notification |= (if any(.[].hooks[]?; .command | test("macos-notify")) then . else . + [{"hooks":[{"type":"command","command":"bash ~/.claude/hooks/macos-notify.sh","timeout":10}]}] end) |
+  .hooks.Stop |= (if any(.[].hooks[]?; .command | test("macos-notify")) then . else . + [{"hooks":[{"type":"command","command":"bash ~/.claude/hooks/macos-notify.sh","timeout":10}]}] end)
+' ~/.claude/settings.json > "$tmp" && mv "$tmp" ~/.claude/settings.json
+```
+
+Schreibt Claude Code / Supacode die Datei neu und entfernt dabei den Eintrag,
+das Snippet einfach erneut ausführen.
+
+## settings.json ist app-verwaltet
+
+`~/.claude/settings.json` wird von Claude Code und Supacode zur Laufzeit neu
+geschrieben (Format + agent-integration Hooks). Sie ist daher bewusst **nicht**
+gestowt (`claude/.stow-local-ignore` schließt sie aus), sondern bleibt eine
+echte, app-verwaltete Datei. Eigene Hooks werden wie oben in die Live-Datei
+gemergt, nicht ins Repo committet. Der Rest des `claude`-Packages (`agents`,
+`hooks`, `skills`, `CLAUDE.md`, …) wird normal gestowt.
+
+## Erststart nach dem Merge
+
+```sh
+cd ~/dotfiles && task setup   # foldet ~/bin, installiert gh-dash
+```
+
+Anschließend eine frische Zellij-Session starten (nicht eine wiederhergestellte),
+damit das `dev`-Layout greift.

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -17,8 +17,8 @@ tasks:
     desc: validate claude config (JSON + shell syntax)
     cmds:
       - jq -e . claude/.claude/settings.json >/dev/null
-      - for f in claude/.claude/hooks/*.sh claude/.claude/statusline-command.sh; do bash -n "$f"; done
-      - if command -v shellcheck >/dev/null; then shellcheck claude/.claude/hooks/*.sh claude/.claude/statusline-command.sh; fi
+      - for f in claude/.claude/hooks/*.sh claude/.claude/statusline-command.sh zsh/bin/*; do if [ -f "$f" ]; then bash -n "$f"; fi; done
+      - if command -v shellcheck >/dev/null; then for f in claude/.claude/hooks/*.sh claude/.claude/statusline-command.sh zsh/bin/*; do if [ -f "$f" ]; then shellcheck "$f"; fi; done; fi
 
   clone-plugins:
     vars:


### PR DESCRIPTION
Supacode-Ablösung Teil 3: Agent-Notifications und Doku des Workflow-Ersatzes.

## Änderungen
- `claude/.claude/hooks/macos-notify.sh` — macOS-Banner (mit Sound) bei `Notification` (Agent wartet) und `Stop` (fertig); Zellij-Session im Titel. Injection-sicher (osascript via argv). No-op innerhalb Supacode.
- `claude/.stow-local-ignore` — nimmt `settings.json` aus dem stow-Management. **Grund (RCA):** Claude Code / Supacode schreiben `~/.claude/settings.json` zur Laufzeit neu (Format + agent-integration Hooks, live bereits auf ein OSC-3008-Protokoll migriert). Das ließ `stow claude` scheitern und würde die Live-Änderungen der App zurückdrehen. Die Datei bleibt app-verwaltet. Die Ignore-Liste wiederholt stows eingebaute Defaults, die eine eigene Liste ersetzt (sonst würde `README.md` nach `~` gestowt).
- `taskfile.yml` — `check` deckt jetzt `zsh/bin/*` mit ab (defensiv via `if [ -f ]`).
- `docs/zellij-workflow.md` — dokumentiert wt, Sessionizer, gh-dash-Layout, zjstatus-Rückbau, Notifications **und** das idempotente jq-Snippet, mit dem der Notify-Hook in die app-verwaltete settings.json eingepflegt wird.

Die macos-notify-Verdrahtung wird **nicht** ins Repo committet, sondern per jq in die Live-`settings.json` gemergt (Snippet in der Doku; getestet: idempotent, erhält die supacode-OSC-Hooks).

## Test
- `task check` grün.
- Notify-Hook funktional (osascript gestubbt): Notification→Banner mit Session-Titel, Stop→„Done: <dir>", Supacode→No-op, unbekanntes Event→No-op; echter osascript-Aufruf exit 0.
- `stow -n` Dry-Run: settings.json übersprungen, README ignoriert, alle übrigen `.claude`-Einträge verlinkt.
- jq-Snippet gegen echte Live-settings.json: fügt Einträge hinzu (1→2), erhält OSC-Supacode-Hooks, idempotent beim zweiten Lauf.

Closes #5