### PR TITLE
UI-Rückbau: default_layout zurück auf compact

### DIFF
--- a/zellij/.config/zellij/config.kdl
+++ b/zellij/.config/zellij/config.kdl
@@ -295,7 +295,7 @@ default_mode "normal"
 
 default_shell "zsh"
 
-default_layout "dev-zjstatus"
+default_layout "compact"
 
 pane_frames false
 


### PR DESCRIPTION
Die permanente gh-dash-Sidebar + zjstatus-Bar sind im Alltag unübersichtlich (gh-dash rendert eine riesige Leerfläche, benannte Tabs verschwinden). default_layout zurück auf compact.

- Tabs wieder sichtbar (Stock compact-bar), keine dauerhafte Sidebar.
- `Ctrl f`-Sessionizer + Pane-Mode `g` (on-demand gh-dash) bleiben.
- dev/dev-zjstatus-Layouts + zjstatus.wasm bleiben als inerte Dateien liegen (separat entfernbar).

`zellij setup --check` grün.

Closes #7