### PR TITLE
clone-plugins: go-task-Template statt leerer Shell-Var

### DIFF
--- a/taskfile.yml
+++ b/taskfile.yml
@@ -25,8 +25,8 @@ tasks:
       ZSH_CUSTOM:
         sh: echo "$HOME/.config/ohmyzsh/custom"
     cmds:
-      - mkdir -p $ZSH_CUSTOM/plugins
-      - if [ ! -d "$ZSH_CUSTOM/plugins/copyzshell" ]; then git clone git@github.com:rutchkiwi/copyzshell.git $ZSH_CUSTOM/plugins/copyzshell; fi
-      - if [ ! -d "$ZSH_CUSTOM/plugins/zsh-peco-history" ]; then git clone git@github.com:jimeh/zsh-peco-history.git $ZSH_CUSTOM/plugins/zsh-peco-history; fi
-      - if [ ! -d "$ZSH_CUSTOM/plugins/kubetail" ]; then git clone git@github.com:johanhaleby/kubetail.git $ZSH_CUSTOM/plugins/kubetail; fi
+      - mkdir -p {{.ZSH_CUSTOM}}/plugins
+      - if [ ! -d "{{.ZSH_CUSTOM}}/plugins/copyzshell" ]; then git clone git@github.com:rutchkiwi/copyzshell.git {{.ZSH_CUSTOM}}/plugins/copyzshell; fi
+      - if [ ! -d "{{.ZSH_CUSTOM}}/plugins/zsh-peco-history" ]; then git clone git@github.com:jimeh/zsh-peco-history.git {{.ZSH_CUSTOM}}/plugins/zsh-peco-history; fi
+      - if [ ! -d "{{.ZSH_CUSTOM}}/plugins/kubetail" ]; then git clone git@github.com:johanhaleby/kubetail.git {{.ZSH_CUSTOM}}/plugins/kubetail; fi
 


### PR DESCRIPTION
`$ZSH_CUSTOM` in den cmds wird von go-task nicht als Shell-Env exportiert → leer → `mkdir -p /plugins` / `git clone … /plugins/…` scheitern. Fix: `{{.ZSH_CUSTOM}}`.

Verifiziert: `--dry` + realer idempotenter Lauf zeigen den korrekten Pfad `~/.config/ohmyzsh/custom/plugins`, `/plugins` wird nicht mehr erstellt.

Closes #11