### PR TITLE
fix(claude): map workflow agentTypes to real agents

### DIFF
--- a/claude/.claude/workflows/audit.js
+++ b/claude/.claude/workflows/audit.js
@@ -44,8 +44,8 @@ const VERDICT_SCHEMA = {
 const DIMENSIONS = [
   { key: 'k8s-enabled', agentType: 'kubernetes-expert', lens: 'Helm/manifest components: does a referenced component (alertmanager_url, *_url, [[plugin]], a values section) actually have its enabled-flag set AND a workload? Flag config that merely points at something as NOT proven deployed (set claimsLiveState=true).' },
   { key: 'iac', agentType: 'terraform-architect', lens: 'Terraform/OpenTofu: drift risk, unpinned versions, state/backend issues, module hygiene.' },
-  { key: 'security', agentType: 'security', lens: 'secrets in plain text, over-broad RBAC, unsafe defaults, missing network policy.' },
-  { key: 'debt', agentType: 'technical-debt-analyzer', lens: 'accumulated debt, deprecated APIs, duplicated config, dead resources.' },
+  { key: 'security', lens: 'secrets in plain text, over-broad RBAC, unsafe defaults, missing network policy.' },
+  { key: 'debt', agentType: 'code-quality-pragmatist', lens: 'accumulated debt, deprecated APIs, duplicated config, dead resources.' },
 ]
 
 phase('Sweep')
@@ -55,7 +55,7 @@ const sweep = (
       agent(
         `Audit target "${target}" ONLY through the ${d.key} lens: ${d.lens} ` +
           `Use read-only tools (rg, kubectl get, helm get values, tofu show) where available. Report concrete findings.`,
-        { agentType: d.agentType, label: `sweep:${d.key}`, phase: 'Sweep', schema: FINDINGS_SCHEMA },
+        { ...(d.agentType && { agentType: d.agentType }), label: `sweep:${d.key}`, phase: 'Sweep', schema: FINDINGS_SCHEMA },
       ),
     ),
   )

--- a/claude/.claude/workflows/pr-review-deep.js
+++ b/claude/.claude/workflows/pr-review-deep.js
@@ -43,9 +43,9 @@ const VERDICT_SCHEMA = {
 }
 
 const DIMENSIONS = [
-  { key: 'correctness', agentType: 'reviewer', lens: 'bugs, logic errors, unhandled edge cases, error handling' },
-  { key: 'security', agentType: 'security', lens: 'vulnerabilities, leaked secrets, unsafe defaults, RBAC/permissions' },
-  { key: 'conventions', agentType: 'claude-md-compliance-checker', lens: 'CLAUDE.md + coding-rules: English code/comments, no what-comments, commit/PR conventions, English-only in Talos base repos' },
+  { key: 'correctness', lens: 'bugs, logic errors, unhandled edge cases, error handling' },
+  { key: 'security', lens: 'vulnerabilities, leaked secrets, unsafe defaults, RBAC/permissions' },
+  { key: 'conventions', lens: 'CLAUDE.md + coding-rules: English code/comments, no what-comments, commit/PR conventions, English-only in Talos base repos' },
   { key: 'infra', agentType: 'kubernetes-expert', lens: 'for k8s/helm/manifest/IaC changes: enabled-flags vs actually-deployed state, resource correctness. If no infra files changed, return no findings' },
 ]
 
@@ -56,7 +56,7 @@ const results = await pipeline(
     agent(
       `Run \`${diffCmd}\` to get the diff. Review ONLY through the ${d.key} lens: ${d.lens}. ` +
         `Report concrete findings with file and line. No nitpicks.`,
-      { agentType: d.agentType, label: `review:${d.key}`, phase: 'Review', schema: FINDINGS_SCHEMA },
+      { ...(d.agentType && { agentType: d.agentType }), label: `review:${d.key}`, phase: 'Review', schema: FINDINGS_SCHEMA },
     ),
   (review, d) =>
     parallel(
@@ -65,7 +65,7 @@ const results = await pipeline(
           `Adversarially verify this review finding — try to REFUTE it. Default to refuted=true if ` +
             `uncertain or if it is a stylistic nitpick. Use \`${diffCmd}\` and the repo for context.\n\n` +
             `Finding: ${JSON.stringify(f)}`,
-          { agentType: 'reviewer', label: `verify:${d.key}`, phase: 'Verify', schema: VERDICT_SCHEMA },
+          { label: `verify:${d.key}`, phase: 'Verify', schema: VERDICT_SCHEMA },
         ).then((v) => ({ ...f, dimension: d.key, verdict: v })),
       ),
     ),

--- a/claude/.claude/workflows/sdd-plan.js
+++ b/claude/.claude/workflows/sdd-plan.js
@@ -87,7 +87,7 @@ const LENSES = [
   },
   {
     key: 'architecture-risk',
-    agentType: 'software-architect',
+    agentType: 'castiel',
     prompt:
       `Review this plan for architectural soundness and risk: ordering, hidden coupling, ` +
       `failure modes, infra enabled-flags/dependencies. Report weak points as gaps.`,


### PR DESCRIPTION
## What

Five agentTypes used in workflow scripts exist neither in `agents/` nor in the built-in registry — the affected `agent()` calls fail at runtime, leaving `sdd-plan`, `audit` and `pr-review-deep` partially broken.

- `software-architect` → `castiel` (sdd-plan.js, architecture-risk critique lens)
- `technical-debt-analyzer` → `code-quality-pragmatist` (audit.js, debt lens)
- `reviewer`, `security`, `claude-md-compliance-checker` → **default workflow subagent** (agentType dropped): the lens is already in the prompt, and specialists like `team-red` are Read/Grep-only while these stages must run `git diff`/`kubectl`
- call sites guard against `agentType: undefined` via conditional spread

All three scripts syntax-checked as async function bodies (matching the workflow runtime).

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)