### PR TITLE
ci: validate claude harness

### DIFF
--- a/.github/workflows/harness-ci.yml
+++ b/.github/workflows/harness-ci.yml
@@ -27,6 +27,8 @@ jobs:
         run: |
           fail=0
           for f in claude/.claude/agents/*.md claude/.claude/skills/*/SKILL.md; do
+            # symlinked skills (e.g. hunk-review -> homebrew) resolve only on the host machine
+            [ -L "$f" ] && continue
             head -1 "$f" | grep -qx -- '---' \
               || { echo "::error file=$f::missing frontmatter"; fail=1; continue; }
             fm=$(awk '/^---$/{n++; next} n==1{print}' "$f")

--- a/.github/workflows/harness-ci.yml
+++ b/.github/workflows/harness-ci.yml
@@ -1,0 +1,52 @@
+name: harness-ci
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Syntax-check workflow scripts
+        # the workflow runtime executes scripts as an async function body,
+        # so top-level await/return are legal — wrap before node --check
+        run: |
+          for f in claude/.claude/workflows/*.js; do
+            { printf 'async function wf() {\n'
+              sed 's/^export const meta/const meta/' "$f"
+              printf '}\n'
+            } | node --input-type=module --check \
+              || { echo "::error file=$f::syntax error"; exit 1; }
+          done
+
+      - name: Lint agent and skill frontmatter
+        run: |
+          fail=0
+          for f in claude/.claude/agents/*.md claude/.claude/skills/*/SKILL.md; do
+            head -1 "$f" | grep -qx -- '---' \
+              || { echo "::error file=$f::missing frontmatter"; fail=1; continue; }
+            fm=$(awk '/^---$/{n++; next} n==1{print}' "$f")
+            printf '%s\n' "$fm" | grep -q '^name:' \
+              || { echo "::error file=$f::frontmatter missing name"; fail=1; }
+            printf '%s\n' "$fm" | grep -q '^description:' \
+              || { echo "::error file=$f::frontmatter missing description"; fail=1; }
+          done
+          exit $fail
+
+      - name: Cross-check workflow agentTypes against agents
+        run: |
+          builtin_types=' Explore Plan general-purpose claude '
+          fail=0
+          for t in $(grep -hoE "agentType: '[^']+'" claude/.claude/workflows/*.js \
+                     | sed "s/agentType: '//; s/'$//" | sort -u); do
+            if [ ! -f "claude/.claude/agents/$t.md" ] \
+               && ! printf '%s' "$builtin_types" | grep -q " $t "; then
+              echo "::error::agentType '$t' resolves to no agents/$t.md and no built-in"
+              fail=1
+            fi
+          done
+          exit $fail


### PR DESCRIPTION
## What

Adds `harness-ci.yml` (pull_request + push to main) with three checks over the vendored Claude harness:

1. **Workflow JS syntax** — each `workflows/*.js` wrapped as an async function body (matching the workflow runtime, where top-level `return`/`await` are legal), then `node --check`
2. **Frontmatter lint** — `agents/*.md` and `skills/*/SKILL.md` must carry `name` + `description`
3. **agentType cross-ref** — every `agentType: '...'` in workflow scripts must resolve to `agents/<type>.md` or a built-in (`Explore`, `Plan`, `general-purpose`, `claude`)

All three checks dry-run locally; check 3 correctly flags the five dangling agentTypes that #19 fixes.

`actions/checkout` pinned at the verified current upstream release (v7.0.0, 2026-06-18).

**Merge order: #19 first** — until then, check 3 legitimately fails on the main merge-ref.

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)