### PR TITLE
fix(hooks): close context-guard fail-open and bypass gaps

### DIFF
--- a/claude/.claude/hooks/context-guard.sh
+++ b/claude/.claude/hooks/context-guard.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 # PreToolUse(Bash) guard: block mutating cluster commands against non-allowed contexts.
 # Convention: local playground contexts are always allowed; every remote context must
-# be listed (glob per line, # = comment) in ~/.claude/allowed-contexts. Fail-closed.
+# be listed (glob per line, # = comment) in ~/.claude/allowed-contexts. Fail-closed:
+# a mutating command whose target context cannot be resolved or is not allowed is blocked.
 #
-# Covered: kubectl, helm, talosctl, argocd. Target context comes from an explicit
-# --context/--kube-context flag, else the current context of the matching tool.
+# Covered: kubectl, helm, talosctl, argocd. Target context comes from explicit
+# --context/--kube-context flags, else the current context of the matching tool.
+# A compound command (;, &&, ||, &) is evaluated against every candidate context —
+# all must be allowed. A context whose NAME looks local but whose server endpoint is
+# remote is NOT exempted (kube tools); talosctl local exemption stays name-only.
 # Best-effort: shell tricks (cd, aliases, wrappers, env -i) are not caught.
 set -euo pipefail
 
@@ -21,34 +25,73 @@ elif printf '%s' "$cmd" | grep -qE '(^|[;&|[:space:]])helm[[:space:]]+(.*[[:spac
   mutating='helm'
 elif printf '%s' "$cmd" | grep -qE '(^|[;&|[:space:]])talosctl[[:space:]]+(.*[[:space:]])?(apply-config|patch|edit|reset|reboot|shutdown|bootstrap|upgrade|upgrade-k8s)([[:space:]]|$)'; then
   mutating='talosctl'
-elif printf '%s' "$cmd" | grep -qE '(^|[;&|[:space:]])argocd[[:space:]]+app[[:space:]]+(sync|delete|create|set|unset|patch|rollback|terminate-op)([[:space:]]|$)'; then
+elif printf '%s' "$cmd" | grep -qE '(^|[;&|[:space:]])argocd[[:space:]]+(app|proj|repo|cluster|appset|account|cert|gpg)[[:space:]]+(create|delete|rm|add|set|unset|patch|rollback|sync|terminate-op|update-password)([[:space:]]|$)'; then
   mutating='argocd'
 else
   exit 0
 fi
 
-ctx=$(printf '%s' "$cmd" | sed -nE 's/.*--(kube-)?context[= ]([^[:space:]]+).*/\2/p')
-if [ -z "$ctx" ]; then
+host_is_local() {
+  case "$1" in
+    127.*|::1|localhost|0.0.0.0|host.docker.internal) return 0 ;;
+    10.*|192.168.*) return 0 ;;
+    172.1[6-9].*|172.2[0-9].*|172.3[01].*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+ctx_allowed() {
+  ctx=$1
+  [ -n "$ctx" ] || return 1
+  if printf '%s' "$ctx" | grep -qE "^(${LOCAL_PATTERNS})$"; then
+    if [ "$mutating" = talosctl ]; then return 0; fi
+    server=$(kubectl config view --minify --context="$ctx" -o jsonpath='{.clusters[0].cluster.server}' 2>/dev/null || true)
+    host=${server#*://}; host=${host%%[:/]*}
+    host_is_local "$host" && return 0
+  fi
+  if [ -f "$ALLOWFILE" ]; then
+    while IFS= read -r pattern; do
+      case "$pattern" in ''|'#'*) continue ;; esac
+      case "$pattern" in
+        '*'|'?'|'['*)
+          echo "context-guard: ignoring wildcard allowlist entry '${pattern}' in ${ALLOWFILE} (would match every context)." >&2
+          continue ;;
+      esac
+      # shellcheck disable=SC2254
+      case "$ctx" in $pattern) return 0 ;; esac
+    done < "$ALLOWFILE"
+  fi
+  return 1
+}
+
+flag_ctxs=$(printf '%s' "$cmd" | grep -oE -- '--(kube-)?context[=[:space:]][^[:space:]]+' | sed -E 's/^--(kube-)?context[=[:space:]]//' || true)
+n_flags=$(printf '%s' "$flag_ctxs" | grep -c . || true)
+compound=0
+printf '%s' "$cmd" | grep -qE '[;&]|\|\|' && compound=1
+
+current=''
+if [ -z "$flag_ctxs" ] || [ "$compound" = 1 ] || [ "$n_flags" -gt 1 ]; then
   case "$mutating" in
     kubectl|helm|argocd)
-      ctx=$(kubectl config current-context 2>/dev/null || true) ;;
+      current=$(kubectl config current-context 2>/dev/null || true) ;;
     talosctl)
-      ctx=$(talosctl config info 2>/dev/null | sed -nE 's/^[[:space:]]*Current context:[[:space:]]*([^[:space:]]+).*/\1/p' || true) ;;
+      current=$(talosctl config info 2>/dev/null | sed -nE 's/^[[:space:]]*Current context:[[:space:]]*([^[:space:]]+).*/\1/p' || true) ;;
   esac
-fi
-[ -n "$ctx" ] || exit 0
-
-if printf '%s' "$ctx" | grep -qE "^(${LOCAL_PATTERNS})$"; then
-  exit 0
-fi
-
-if [ -f "$ALLOWFILE" ]; then
-  while IFS= read -r pattern; do
-    case "$pattern" in ''|'#'*) continue ;; esac
-    # shellcheck disable=SC2254
-    case "$ctx" in $pattern) exit 0 ;; esac
-  done < "$ALLOWFILE"
+  if [ -z "$flag_ctxs" ] && [ -z "$current" ]; then
+    echo "Blocked: mutierendes ${mutating}-Kommando, aber Ziel-Context nicht auflösbar (kein --context, current-context leer). Fail-closed." >&2
+    exit 2
+  fi
 fi
 
-echo "Blocked: mutierendes ${mutating}-Kommando gegen Context '${ctx}' (nicht in ${ALLOWFILE}). Lokale Contexts (kind-*, minikube, ...) sind immer erlaubt. Freigeben: 'echo \"${ctx}\" >> ${ALLOWFILE}' — bewusst, pro Cluster." >&2
-exit 2
+candidates=$(printf '%s\n%s\n' "$flag_ctxs" "$current" | grep -v '^$' | sort -u || true)
+while IFS= read -r c; do
+  [ -n "$c" ] || continue
+  if ! ctx_allowed "$c"; then
+    echo "Blocked: mutierendes ${mutating}-Kommando gegen Context '${c}' (nicht in ${ALLOWFILE}). Lokale Contexts (kind-*, minikube, ...) sind erlaubt, wenn ihr Endpoint lokal ist. Freigeben: 'echo \"${c}\" >> ${ALLOWFILE}' — bewusst, pro Cluster." >&2
+    exit 2
+  fi
+done <<EOF
+$candidates
+EOF
+
+exit 0


### PR DESCRIPTION
## What

Five confirmed bypasses in the cluster-mutation guard (wargame r1-4, r3-1, r3-2, r3-8, r1-8):

- **r1-4 fail-open → fail-closed**: a mutating command whose target context can't be resolved (no `--context`, empty current-context) now blocks (exit 2) instead of `exit 0`.
- **r3-1 compound binding**: a compound command (`;`, `&&`, `||`, `&`) no longer lets one segment's `--context` cover another segment's mutating verb. Every candidate context (all `--context` flags **plus** current-context when a flagless mutating segment can exist) is checked; if any is not allowed, block.
- **r3-2 argocd coverage**: extended beyond `argocd app <verb>` to `proj`/`repo`/`cluster`/`appset`/`account`/`cert`/`gpg` destructive verbs, matching the header's "Covered: argocd" claim.
- **r3-8 name vs endpoint**: a context whose *name* matches local patterns (`kind-*`, `minikube`, …) is only exempted if its server *endpoint* resolves to loopback / RFC1918-local. A remote cluster merged as `kind-prod` is now checked against the allowlist. talosctl stays name-only (documented).
- **r1-8 wildcard allowlist**: a `*` / `?` / `[…` entry in `allowed-contexts` is ignored with a stderr warning instead of granting blanket access.

## Test

11 scenarios with a stubbed `kubectl` (context + endpoint resolution) — read-only pass-through, fail-closed on empty context, allowed/unlisted remotes, the r3-1 compound attack, name-local-but-remote-endpoint, genuine-local, argocd proj delete, and wildcard-allowlist rejection. All behave as intended. `bash -n` clean.

## Residual (documented in header + backlog)

Shell tricks (cd, aliases, wrappers, `env -i`) remain uncaught by design; an RFC1918 remote masquerading as local still passes the endpoint check.

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)