### PR TITLE
fix(hooks): guard compound git commits in worktree-guard

### DIFF
--- a/claude/.claude/hooks/worktree-guard.sh
+++ b/claude/.claude/hooks/worktree-guard.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 # PreToolUse(Bash) guard: block `git commit` / `git push` from a main checkout.
 # Convention: commit in a worktree, never in the main checkout (parallel sessions).
-# Opt out per repo by creating `.allow-main-commit` at the repo root (e.g. dotfiles).
+# Opt out per repo with `.allow-main-commit` at the repo root (e.g. dotfiles, a
+# single-author repo with no parallel-session WIP).
 #
 # Best-effort: catches plain `git commit|push` and `git -C <path> commit|push`,
-# checked against the repo at -C path resp. the session cwd from the hook payload.
+# checked against the repo at each -C path and (for a flagless commit|push) the
+# session cwd. Every commit|push target in a compound command must clear the guard.
 # Shell tricks (cd first, aliases, wrappers) are not caught — safety net, not a wall.
 set -euo pipefail
 
@@ -16,17 +18,34 @@ printf '%s' "$cmd" \
   | grep -qE '(^|[;&|[:space:]])git[[:space:]]+(-C[[:space:]]+[^[:space:]]+[[:space:]]+)?(commit|push)([[:space:]]|$)' \
   || exit 0
 
-dir=$(printf '%s' "$cmd" | sed -nE 's/.*git[[:space:]]+-C[[:space:]]+([^[:space:]]+)[[:space:]]+(commit|push).*/\1/p')
-[ -n "$dir" ] || dir=${cwd:-.}
-dir=${dir/#\~/$HOME}
+blocked_root=''
+is_main_checkout() {
+  dir=${1/#\~/$HOME}
+  gitdir=$(git -C "$dir" rev-parse --git-dir 2>/dev/null) || return 1
+  case "$gitdir" in *"/worktrees/"*) return 1 ;; esac
+  root=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null || echo "")
+  if [ -n "$root" ] && [ -f "$root/.allow-main-commit" ]; then
+    return 1
+  fi
+  blocked_root=$root
+  return 0
+}
 
-gitdir=$(git -C "$dir" rev-parse --git-dir 2>/dev/null) || exit 0
-case "$gitdir" in
-  *"/worktrees/"*) exit 0 ;;
-esac
+while IFS= read -r dir; do
+  [ -n "$dir" ] || continue
+  if is_main_checkout "$dir"; then
+    echo "Blocked: git commit/push im Hauptcheckout (${blocked_root:-?}). Konvention: in einem Worktree committen (git worktree add <tmp> origin/main -b <branch>). Opt-out fuer dieses Repo: 'touch ${blocked_root:-.}/.allow-main-commit'." >&2
+    exit 2
+  fi
+done <<EOF
+$(printf '%s' "$cmd" | grep -oE 'git[[:space:]]+-C[[:space:]]+[^[:space:]]+[[:space:]]+(commit|push)' | sed -E 's/git[[:space:]]+-C[[:space:]]+([^[:space:]]+)[[:space:]]+(commit|push)/\1/')
+EOF
 
-root=$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null || echo "")
-[ -n "$root" ] && [ -f "$root/.allow-main-commit" ] && exit 0
+if printf '%s' "$cmd" | grep -qE '(^|[;&|[:space:]])git[[:space:]]+(commit|push)([[:space:]]|$)'; then
+  if is_main_checkout "${cwd:-.}"; then
+    echo "Blocked: git commit/push im Hauptcheckout (${blocked_root:-?}). Konvention: in einem Worktree committen (git worktree add <tmp> origin/main -b <branch>). Opt-out fuer dieses Repo: 'touch ${blocked_root:-.}/.allow-main-commit'." >&2
+    exit 2
+  fi
+fi
 
-echo "Blocked: git commit/push im Hauptcheckout (${root:-?}). Konvention: in einem Worktree committen (git worktree add <tmp> origin/main -b <branch>). Opt-out fuer dieses Repo: 'touch ${root:-.}/.allow-main-commit'." >&2
-exit 2
+exit 0


### PR DESCRIPTION
## What

**r1-7 compound pin**: the guard extracted a single `git -C <dir>` path, so `git -C /wt commit; git commit` pinned the safe worktree and let the trailing bare `git commit` in the main checkout through. Now every commit/push target is checked — each `-C <dir> commit|push` **and** the cwd for a flagless `commit|push`; any main-checkout target blocks.

## Scope note (r3-10 intentionally not applied)

The wargame also flagged that a tracked `.allow-main-commit` self-propagates to clones (r3-10). Per decision, `.allow-main-commit` stays **tracked and effective** — dotfiles is a sanctioned single-author exception with no parallel-session WIP. The guard honors the opt-out whenever the file is present (tracked or not); the self-propagation is an accepted, documented residual (see THREAT-MODEL, #38). This PR is now purely the r1-7 fix.

## Test

Real git repos (main + worktree): the r1-7 compound attack blocks, bare commit in a worktree passes, a present `.allow-main-commit` is honored, and a main checkout without it blocks. `bash -n` clean.

Closes #25