### PR TITLE
fix(settings): deny secret-leaking helm/kubectl reads

### DIFF
--- a/claude/.claude/settings.seed.json
+++ b/claude/.claude/settings.seed.json
@@ -61,7 +61,10 @@
       "Bash(kubectl events *)",
       "Bash(helm list *)",
       "Bash(helm status *)",
-      "Bash(helm get *)",
+      "Bash(helm get manifest *)",
+      "Bash(helm get notes *)",
+      "Bash(helm get hooks *)",
+      "Bash(helm get metadata *)",
       "Bash(helm history *)",
       "Bash(helm show *)",
       "Bash(helm search *)",
@@ -83,7 +86,11 @@
       "Bash(kubectl get secret*)",
       "Bash(kubectl get -n * secret*)",
       "Bash(kubectl get --namespace * secret*)",
-      "Bash(kubectl describe secret*)"
+      "Bash(kubectl get * secret*)",
+      "Bash(kubectl get *secrets.v1.*)",
+      "Bash(kubectl describe secret*)",
+      "Bash(helm get values *)",
+      "Bash(helm get all *)"
     ]
   },
   "skipAutoPermissionPrompt": true,

--- a/claude/README.md
+++ b/claude/README.md
@@ -34,6 +34,16 @@ Supacode injects its `# supacode-managed-hook` entries into the live file on
 first run. After deliberate settings changes, fold them back into the seed
 (minus the supacode hooks).
 
+## Secret exposure — what the permission list can and cannot do
+
+The `permissions.deny` list blocks the obvious secret reads (`kubectl get
+secret*`, `helm get values`/`all`). It is a string matcher, not a content
+filter: it cannot express "no secret content". `kubectl get <resource> -o
+yaml/jsonpath` on any secret-bearing object (a ServiceAccount token, a
+ConfigMap holding credentials, a workload with inline env secrets) still
+exfiltrates them and stays the operator's responsibility. Durable closure
+would need an allow-only-non-secret model, not attempted here.
+
 ## Intentionally NOT managed here
 
 - `settings.json` — machine-managed by supacode (see above)


### PR DESCRIPTION
## What

The permission deny-list matched only the literal token `secret` while `Bash(helm get *)` was an open allow — `helm get values`/`all` dump plaintext release credentials (wargame r1-6, r3-9).

- `Bash(helm get *)` blanket allow → safe subverbs only: `manifest`, `notes`, `hooks`, `metadata`
- deny added: `Bash(helm get values *)`, `Bash(helm get all *)` (deny wins over allow, so these are load-bearing)
- kubectl secret deny strengthened: `Bash(kubectl get * secret*)` (flags before the resource) and `Bash(kubectl get *secrets.v1.*)`
- README documents the residual: a string deny-list cannot express "no secret content" — `-o yaml/jsonpath` on secret-bearing resources still leaks and stays operator responsibility

## Note

`readyToImplement`-style content filtering is explicitly out of scope (documented residual). This closes the always-exploitable `helm get values` hole, not the general problem.

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)