### PR TITLE
fix(hooks): resolve jq robustly in macos-notify

### DIFF
--- a/claude/.claude/hooks/macos-notify.sh
+++ b/claude/.claude/hooks/macos-notify.sh
@@ -9,14 +9,18 @@ set -euo pipefail
 if [ -n "${SUPACODE_SOCKET_PATH:-}" ]; then exit 0; fi
 if [ "${__CFBundleIdentifier:-}" = "app.supabit.supacode" ]; then exit 0; fi
 
+jq=$(command -v jq || true)
+[ -n "$jq" ] || exit 0
+
 payload=$(cat)
-event=$(printf '%s' "$payload" | /usr/bin/jq -r '.hook_event_name // empty')
-cwd=$(printf '%s' "$payload" | /usr/bin/jq -r '.cwd // empty')
+event=$(printf '%s' "$payload" | "$jq" -r '.hook_event_name // empty' 2>/dev/null || true)
+cwd=$(printf '%s' "$payload" | "$jq" -r '.cwd // empty' 2>/dev/null || true)
 dir=$(basename "${cwd:-$PWD}")
 
 case "$event" in
 Notification)
-	msg=$(printf '%s' "$payload" | /usr/bin/jq -r '.message // "Notification"')
+	msg=$(printf '%s' "$payload" | "$jq" -r '.message // "Notification"' 2>/dev/null || true)
+	[ -n "$msg" ] || msg="Notification"
 	;;
 Stop)
 	msg="Done: $dir"


### PR DESCRIPTION
## What

`macos-notify.sh` ran `set -euo pipefail` with a hardcoded, unguarded `/usr/bin/jq` (wargame r2-7). On a machine without jq at that path (Homebrew on Apple Silicon → `/opt/homebrew/bin/jq`), the failed command substitution aborts the script on every Notification/Stop event.

- jq resolved via `command -v jq`; if absent, the hook exits 0 (silent no-op) instead of aborting the event
- all jq parses guarded with `2>/dev/null || true`, matching the sibling guard scripts

## Note

On the current machine jq is at `/usr/bin/jq` (macOS 15 ships it), so the hook works today — this is portability hardening for other machines / fresh installs.

## Test

`bash -n` clean; verified jq-missing → `exit 0` (no abort) and a normal Stop event → `exit 0`.

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)