### PR TITLE
docs(wargame): align agent contract and convergence with workflow

### DIFF
--- a/claude/.claude/agents/team-blue.md
+++ b/claude/.claude/agents/team-blue.md
@@ -30,6 +30,8 @@ For every red finding, take exactly one stance:
 
 ## Output Format
 
+> Invocation note: the `wargame` workflow supplies a JSON output schema that supersedes this prose format at runtime. The prose below is the shape for the sequential (skill) invocation, where no schema is passed.
+
 ---
 
 ### Defense — Round [N if known]

--- a/claude/.claude/agents/team-purple.md
+++ b/claude/.claude/agents/team-purple.md
@@ -25,8 +25,11 @@ You receive the plan/diff and the full game transcript (all rounds: red findings
 - **REFUTED** findings produce no backlog items. Do not resurrect them.
 - Merge duplicates: findings that share a root cause become one item listing all source findings.
 - Priorities: **P0** = unmitigated REAL or security-relevant, **P1** = mitigated findings whose fix is not yet applied, **P2** = hardening credited by white but not load-bearing.
+- A finding ruled REAL *only because the referee could not verify it with its tooling* (live-state / external-system claims) carries its **own original severity**, not blanket P0 — such findings routinely survive to game end without being a crisis.
 
 ## Output Format
+
+> Invocation note: the `wargame` workflow supplies a JSON output schema that supersedes this prose format at runtime. The prose below is the shape for the sequential (skill) invocation, where no schema is passed.
 
 ---
 

--- a/claude/.claude/agents/team-red.md
+++ b/claude/.claude/agents/team-red.md
@@ -34,6 +34,8 @@ If the input is ambiguous, default to Pre-Mortem Mode and state your assumption.
 
 ## Output Format
 
+> Invocation note: the `wargame` workflow supplies a JSON output schema that supersedes this prose format at runtime. The prose below is the shape for the sequential (skill) invocation, where no schema is passed.
+
 Produce all five sections. If a section has no findings, write "None found — [one sentence explaining what you checked and why it appears clean]." Do not skip sections.
 
 ---

--- a/claude/.claude/agents/team-white.md
+++ b/claude/.claude/agents/team-white.md
@@ -35,7 +35,11 @@ After the per-finding rulings, rule on the game:
 - **CONTINUE** — open REAL findings remain, or this round produced substantive new material. Another round has signal.
 - **CONVERGED** — no REAL findings remain open, or the round added nothing new (red repeats itself, blue repeats itself). Further rounds are noise.
 
+This Game Ruling is authoritative in the sequential (skill) invocation. In the heavy `wargame` workflow, convergence is derived mechanically from the per-finding verdicts (open REAL == 0) and no separate ruling is read — issue the per-finding verdicts and skip the Game Ruling there.
+
 ## Output Format
+
+> Invocation note: the `wargame` workflow supplies a JSON output schema that supersedes this prose format at runtime. The prose below is the shape for the sequential (skill) invocation, where no schema is passed.
 
 ---
 

--- a/claude/.claude/skills/wargame/SKILL.md
+++ b/claude/.claude/skills/wargame/SKILL.md
@@ -38,9 +38,14 @@ am Ende berichten. Nicht mitspielen, nicht vorab filtern.
 
 ## Abbruchkriterien
 
-- White ruled CONVERGED.
+- White ruled CONVERGED. In der Heavy-Variante wird Konvergenz mechanisch aus
+  den Einzel-Verdikten abgeleitet (offene REAL == 0), nicht aus einem separaten
+  Game-Ruling.
 - Max. Runden erreicht (Default 3; User kann mehr verlangen) → Purple läuft
-  trotzdem, offene REAL-Findings landen als P0 im Backlog.
+  trotzdem. Bei Live-/Infra-Zielen ist das der Normalfall, kein Fehlschlag:
+  White muss unverifizierbare Live-Claims als REAL werten, deshalb konvergiert
+  das Spiel dort selten. Solche „nur mangels Referee-Tooling REAL"-Findings
+  tragen ihre ursprüngliche Schwere, nicht pauschal P0.
 - Red meldet `below red-team threshold` → kein Spiel, dem User so berichten.
 
 ## Heavy-Variante: Workflow `wargame`


### PR DESCRIPTION
## What

Closes the documented-vs-actual drift in the wargame fleet (wargame r1-1, r1-2, r1-9):

- **r1-1**: each of the four wargame agents (red/blue/white/purple) now states in its Output Format that the `wargame` workflow supplies a JSON schema that supersedes the prose, and the prose is the shape for the sequential (skill) path.
- **r1-2**: team-white.md and the wargame SKILL now state the heavy path derives convergence mechanically (open REAL == 0) with no separate Game Ruling; the prose Game Ruling is scoped to the sequential path.
- **r1-9**: team-purple's priority rule now triages a finding that is REAL *only because the referee could not verify it* by its original severity instead of blanket P0; the SKILL documents max-rounds-with-unverifiable-REALs as a normal terminal state for live/infra targets.

Docs only — no schema or code change (the runtime override already works).

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)