### PR TITLE
docs: unify Workflow() shape; scope sdd-plan honestly

### DIFF
--- a/claude/.claude/skills/pr-review/SKILL.md
+++ b/claude/.claude/skills/pr-review/SKILL.md
@@ -7,7 +7,7 @@ description: "Reviewing a GitHub PR and recording the verdict. Use when assessin
 
 Dieser Skill regelt die *Konventionen* (Verdikt, Re-Request-Etikette). Für ein
 inhaltliches Multi-Agent-Review mit adversarialer Verifikation der Findings den
-Workflow `pr-review-deep` nutzen: `Workflow({name: "pr-review-deep"}, "<PR-Nr>")`.
+Workflow `pr-review-deep` nutzen: `Workflow(name: "pr-review-deep", args: "<PR-Nr>")`.
 
 ## Verdikt = formaler GitHub-Status, nicht nur Kommentar
 

--- a/claude/.claude/skills/sdd/SKILL.md
+++ b/claude/.claude/skills/sdd/SKILL.md
@@ -10,8 +10,10 @@ Einzeiler. Leitidee: **Die Spec ist die Source of Truth.** Code wird gegen sie g
 und gegen sie verifiziert; bei Drift gewinnt die Spec (oder die Spec wird bewusst
 geändert), nie der Zufall.
 
-Für größere Vorhaben das Orchestrierungs-Skript nutzen: `Workflow({name: "sdd-plan"})`
-(mehrere Agenten parallel). Dieser Skill ist der manuelle, schrittweise Ablauf.
+Für größere Vorhaben Phase 2 (Plan) mit dem Orchestrierungs-Skript fahren:
+`Workflow(name: "sdd-plan", args: "<Spec-Text oder Pfad>")` (mehrere Kritik-Lenses
+parallel). Der Workflow deckt nur **Plan → Critique → Synthesize** ab; Gate (Phase 4)
+und Verify (Phase 5) bleiben manuell. Dieser Skill ist der vollständige Ablauf.
 
 ## Phase 1 — Spec (Source of Truth)
 

--- a/claude/.claude/workflows/sdd-plan.js
+++ b/claude/.claude/workflows/sdd-plan.js
@@ -59,12 +59,12 @@ const CRITIQUE_SCHEMA = {
 
 const FINAL_SCHEMA = {
   type: 'object',
-  required: ['plan', 'mitigations', 'openQuestions', 'readyToImplement'],
+  required: ['plan', 'mitigations', 'openQuestions', 'critiqueClear'],
   properties: {
     plan: PLAN_SCHEMA,
     mitigations: { type: 'array', items: { type: 'string' } },
     openQuestions: { type: 'array', items: { type: 'string' } },
-    readyToImplement: { type: 'boolean' },
+    critiqueClear: { type: 'boolean' },
   },
 }
 
@@ -118,12 +118,12 @@ const final = await agent(
     `## Spec\n${spec}\n\n## Plan\n${JSON.stringify(plan, null, 2)}\n\n` +
     `## Critiques\n${JSON.stringify(critiques, null, 2)}\n\n` +
     `Fold high-severity gaps into concrete plan changes. List residual mitigations and ` +
-    `open questions. Set readyToImplement=false if any high-severity gap or blocking ` +
+    `open questions. Set critiqueClear=false if any high-severity gap or blocking ` +
     `open question remains.`,
   { agentType: 'castiel', label: 'synthesize', schema: FINAL_SCHEMA },
 )
 
 const highGaps = critiques.flatMap((c) => c.gaps).filter((g) => g.severity === 'high')
-log(`Plan ready: ${final.readyToImplement}. High-severity gaps found: ${highGaps.length}.`)
+log(`Critique clear: ${final.critiqueClear}. High-severity gaps found: ${highGaps.length}.`)
 
 return final


### PR DESCRIPTION
## What

wargame r3-3, r2-2:

- **r3-3**: sdd (`Workflow({name})` — no args), pr-review (`Workflow({name}, "<arg>")` — positional) and wargame (`Workflow(name:, args:)`) documented three different shapes. All three now use the shape matching the actual Workflow tool params: `Workflow(name: "...", args: ...)`. sdd now passes a spec arg (previously it handed `{}`, so sdd-plan.js logged "No spec passed" and planned for nothing).
- **r2-2**: `readyToImplement` in sdd-plan.js renamed to `critiqueClear` (schema field, synthesize prompt, log) — it only reflects the critique check, not a 6-phase completeness bar. The sdd SKILL now scopes the workflow to Plan → Critique → Synthesize and marks Gate (Phase 4) / Verify (Phase 5) as manual.

sdd-plan.js syntax-checked as an async function body.

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)