### PR TITLE
feat(claude): disable accidental mouse-click selection

### DIFF
--- a/claude/.claude/settings.seed.json
+++ b/claude/.claude/settings.seed.json
@@ -4,6 +4,9 @@
     "lua-lsp@claude-plugins-official": true,
     "nono@always-further": true
   },
+  "env": {
+    "CLAUDE_CODE_DISABLE_MOUSE_CLICKS": "1"
+  },
   "hooks": {
     "Notification": [
       {


### PR DESCRIPTION
## Intent
Focusing the terminal window with a mouse click accidentally triggers selections in the Claude Code fullscreen UI. This disables click/drag/hover capture while keeping mouse-wheel scrolling.

## Change
Add `env.CLAUDE_CODE_DISABLE_MOUSE_CLICKS = "1"` to the vendored `claude/.claude/settings.seed.json`. Requires Claude Code >= v2.1.195 and `tui: fullscreen` (already set).

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)