### PR TITLE
feat(nvim): add local diffview review loop

### DIFF
--- a/nvim/.config/nvim/init.lua
+++ b/nvim/.config/nvim/init.lua
@@ -23,6 +23,7 @@ require('lazy').setup {
   require 'plugins.core.gitsigns',
   require 'plugins.core.git-blame',
   require 'plugins.core.fugitive',
+  require 'plugins.core.diffview',
   require 'plugins.core.auto-session',
   require 'plugins.core.autopairs',
   require 'plugins.core.harpoon',

--- a/nvim/.config/nvim/lua/plugins/core/diffview.lua
+++ b/nvim/.config/nvim/lua/plugins/core/diffview.lua
@@ -1,0 +1,25 @@
+-- Local diff review loop: read CC-authored changes like a reviewer.
+-- diffview.nvim is already pulled in as an octo/gitlab dependency; this spec
+-- adds an explicit setup plus keymaps for reviewing the *working tree* and the
+-- *current branch vs origin/main* — the two things you look at after each
+-- Claude Code run. All keys live under the free <leader>gd (Diffview) prefix.
+return {
+  'sindrets/diffview.nvim',
+  config = function()
+    require('diffview').setup {
+      enhanced_diff_hl = true,
+    }
+
+    local wk_ok, wk = pcall(require, 'which-key')
+    if wk_ok then
+      wk.add { { '<leader>gd', group = 'Diffview' } }
+    end
+
+    local map = vim.keymap.set
+    map('n', '<leader>gdd', '<cmd>DiffviewOpen<cr>', { desc = 'Diff: working tree (uncommitted)' })
+    map('n', '<leader>gdm', '<cmd>DiffviewOpen origin/main...HEAD<cr>', { desc = 'Diff: branch vs origin/main (review the session)' })
+    map('n', '<leader>gdh', '<cmd>DiffviewFileHistory %<cr>', { desc = 'Diff: current file history' })
+    map('n', '<leader>gdH', '<cmd>DiffviewFileHistory<cr>', { desc = 'Diff: repo history' })
+    map('n', '<leader>gdq', '<cmd>DiffviewClose<cr>', { desc = 'Diff: close' })
+  end,
+}


### PR DESCRIPTION
Dedizierter diffview.nvim-Setup mit Keymaps unter dem freien Präfix `<leader>gd` (Working-Tree, Branch vs origin/main, Datei-/Repo-Historie) — CC-Änderungen wie im PR-Review lesen.

Closes #51