### PR TITLE
docs: English getting-started guide + translate docs to English

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,98 @@
+# Getting Started — the Claude Code + zellij + nvim workflow
+
+A short guide to the day-to-day working model this setup is built for.
+
+## The idea
+
+Claude Code writes most of the code. Your job shifts from *typing* to *reviewing* —
+and the way you stay connected to the codebase is by **reading diffs like a
+reviewer**, in nvim, after each CC run. The tools are split by role:
+
+- **Claude Code** — writes.
+- **nvim** — your reading / review / navigation surface.
+- **zellij** — one tab per Claude session, with a status bar that shows what each
+  session is doing.
+
+The rule of thumb: *the diff you read is the new code you write.* If you review
+every change as if you had to defend it in a PR, you keep the mental map of the
+codebase alive at full CC speed.
+
+## The daily flow
+
+1. Start a zellij session. The tab bar is **zellaude** — each tab shows its Claude
+   status at a glance (see below).
+2. Work with Claude Code in a tab. One tab = one Claude session.
+3. When CC has produced changes, open a **review tab**:
+   ```sh
+   zellij action new-tab --layout review
+   ```
+   You get nvim (left, 55%) next to Claude Code + a shell (right, 45%).
+4. In nvim, read the change:
+   - `<leader>gdm` — diff of the whole session (branch vs `origin/main`). This is
+     the main review key.
+   - `<leader>gdd` — just the uncommitted working tree.
+   Go through it hunk by hunk. Ask: *would I have written it this way? If not, why
+   did CC?*
+5. The zellaude bar tells you which other tabs need attention (waiting for
+   permission / prompt / done) so you can juggle parallel sessions.
+
+## zellaude tab status
+
+The tab bar shows, per tab: thinking · running bash · editing · ⚠ waiting for
+permission · ▶ waiting for prompt · ✓ done · ○ idle. See
+[zellij-workflow.md](./zellij-workflow.md) for details.
+
+## nvim review keymaps
+
+Leader is `<Space>`.
+
+| Key | Action |
+|---|---|
+| `<leader>gdm` | Diff branch vs `origin/main` — **review the whole session** |
+| `<leader>gdd` | Diff working tree (uncommitted) |
+| `<leader>gdh` / `<leader>gdH` | File history / repo history |
+| `<leader>gdq` | Close diffview |
+| `<leader>gp` | Preview hunk (gitsigns) |
+| `<leader>gt` | Toggle line blame (gitsigns) |
+| `<leader>gs` | Git status picker (telescope) |
+| `<leader>gc` / `<leader>gcf` | Git commits / commits for current file |
+| `<leader>sf` / `<leader>sg` / `<leader>sw` | Find files / live grep / grep word |
+| `<leader>sb` / `<leader>sr` / `<leader>s.` | Buffers / resume / recent files |
+
+## zellij cheat sheet
+
+Press **`Ctrl y`** any time — the `zellij-forgot` plugin shows the live keybindings.
+The essentials:
+
+| Group | Key | Action |
+|---|---|---|
+| Modes | `Ctrl o` / `Ctrl t` / `Ctrl p` | session / tab / pane mode |
+| Modes | `Ctrl n` / `Ctrl m` / `Ctrl s` | resize / move / scroll mode |
+| Modes | `Ctrl g` | lock (pass keys straight to the program) — press again to unlock |
+| Move | `Ctrl h/j/k/l` | move focus (or to the next tab at an edge) |
+| Tabs | `Ctrl i` / `Alt o` | move tab left / right |
+| Panes | `Alt n` / `Alt f` | new pane / toggle floating |
+| Layouts | `Ctrl a` / `Alt a` | next / previous swap layout |
+| Jump | `Ctrl Shift t` | fuzzy jump to pane/tab (`room`) |
+| Tree | `Ctrl o` then `w` | session/tab tree (`choose-tree`) |
+| Quit | `Ctrl q` | quit zellij |
+
+Within a mode: pane mode `n/d/r` new panes, `f` fullscreen, `w` float, `x` close;
+tab mode `n` new, `x` close, `r` rename, `b` break pane.
+
+## Keyboard: Hyper / MEH (Corne)
+
+The Corne exposes a **Hyper** (Ctrl+Shift+Alt+Cmd) and a **MEH** (Ctrl+Shift+Alt)
+modifier. Terminals swallow `Cmd`, so for terminal/zellij shortcuts use **MEH** —
+it is the collision-free "hyper for the terminal" (nvim's `<C-w>`, readline, etc.
+stay untouched). Kitty keyboard protocol is enabled so MEH chords reach zellij.
+
+## First run
+
+```sh
+cd ~/dotfiles && task setup
+```
+
+Then start a fresh zellij session (the zellaude bar and layouts load at session
+start). For plugin/notification/`settings.json` details see
+[zellij-workflow.md](./zellij-workflow.md).

--- a/docs/zellij-workflow.md
+++ b/docs/zellij-workflow.md
@@ -1,54 +1,60 @@
 # Claude Code in Zellij
 
-Arbeitsmodell: **ein Tab pro Claude-Session** in einer Zellij-Session. Supacode
-selbst (Package + Hooks) bleibt koexistent installiert; die hier beschriebenen
-Bausteine sind außerhalb von Supacode aktiv und innerhalb inaktiv.
+Working model: **one tab per Claude session** inside a Zellij session. Supacode
+itself (package + hooks) stays installed alongside; the building blocks described
+here are active outside of Supacode and inactive within it.
 
-## Tab-Status: zellaude
+## Tab status: zellaude
 
-[zellaude](https://github.com/ishefi/zellaude) (v0.5.1, vendored) ersetzt die
-Tab-Bar und zeigt pro Tab den Claude-Code-Status — thinking, running bash,
-editing, waiting for permission (⚠), waiting for prompt (▶), done (✓), idle (○).
-So sieht man auf einen Blick, welche Claude-Session in welchem Tab worauf wartet.
-Gesetzt über `default_layout "zellaude"` (Layout `layouts/zellaude.kdl`).
+[zellaude](https://github.com/ishefi/zellaude) (v0.5.1, vendored) replaces the tab
+bar and shows each tab's Claude Code status — thinking, running bash, editing,
+waiting for permission (⚠), waiting for prompt (▶), done (✓), idle (○). This makes
+it obvious at a glance which Claude session in which tab is waiting for what. Set
+via `default_layout "zellaude"` (layout `layouts/zellaude.kdl`).
 
-Beim ersten Laden schreibt das Plugin selbst `~/.config/zellij/plugins/zellaude-hook.sh`
-und registriert den Hook in der app-verwalteten `~/.claude/settings.json`. Diese
-plugin-generierten Dateien (`zellaude-hook.sh`, `zellaude.json`) sind in
-`.gitignore`, da sie durch den stow-Symlink im Repo landen würden. Laufzeit-Deps:
-`jq`; optional `terminal-notifier` für click-to-focus-Notifications.
+On first load the plugin writes `~/.config/zellij/plugins/zellaude-hook.sh` itself
+and registers the hook in the app-managed `~/.claude/settings.json`. These
+plugin-generated files (`zellaude-hook.sh`, `zellaude.json`) are in `.gitignore`,
+since they would otherwise land in the repo through the stow symlink. Runtime deps:
+`jq`; optionally `terminal-notifier` for click-to-focus notifications.
 
-**Aktivierung:** eine frische Zellij-Session starten (Plugin/Layout laden beim
-Session-Start). Voraussetzung Kompatibilität: zellaude v0.5.1 ist gegen
-`zellij-tile 0.43.1` gebaut = unsere Zellij-Version.
+**Activation:** start a fresh Zellij session (the plugin/layout load at session
+start). Compatibility requirement: zellaude v0.5.1 is built against
+`zellij-tile 0.43.1` = our Zellij version.
 
-### Review-Tab
+### Review tab
 
-`review` (Alias in `.zshrc`) öffnet per `zellij action new-tab --layout review`
-einen Tab mit nvim (Diff/Review, 55%) neben Claude Code + Shell (45%), Layout
-`layouts/review.kdl`. Nutzt dieselbe zellaude-Bar wie das Default-Layout, sodass
-mehrere Review-Tabs oben ihren jeweiligen Claude-Status zeigen.
+Open a review tab with:
+
+```sh
+zellij action new-tab --layout review
+```
+
+This opens a tab with nvim (diff/review, 55%) next to Claude Code + a shell (45%),
+layout `layouts/review.kdl`. It uses the same zellaude bar as the default layout,
+so several review tabs at the top each show their respective Claude status. (If you
+want a shortcut, alias the command as `review` in your `.zshrc`.)
 
 ## Notifications: `macos-notify.sh`
 
-Der Hook feuert bei `Stop` (Agent fertig) ein macOS-Banner mit Sound; der
-Zellij-Session-Name steht im Titel. Permission-/Waiting-Meldungen übernimmt
-**zellaude** (Bar-Symbol + eigenes Banner), daher ist der `Notification`-Zweig
-bewusst **nicht** verdrahtet — sonst doppelte Banner. Innerhalb von Supacode ist
-der Hook ein No-op (`SUPACODE_SOCKET_PATH` / Bundle-ID).
+The hook fires a macOS banner with sound on `Stop` (agent done); the Zellij session
+name is in the title. Permission/waiting messages are handled by **zellaude** (bar
+icon + its own banner), so the `Notification` branch is deliberately **not** wired
+up — otherwise you get duplicate banners. Inside Supacode the hook is a no-op
+(`SUPACODE_SOCKET_PATH` / bundle ID).
 
-Das Skript kommt über den `hooks`-Symlink mit `task setup`. Die **Verdrahtung**
-(macos-notify nur bei `Stop`) ist in `claude/.claude/settings.seed.json`
-deklariert und landet beim Bootstrap in der app-verwalteten
-`~/.claude/settings.json`. Modell + Bootstrap-Schritt (`cp seed → settings.json`,
-supacode injiziert seine Hooks live, bewusste Änderungen in die seed zurückfalten)
-stehen in `claude/README.md` — hier nicht duplizieren.
+The script ships via the `hooks` symlink with `task setup`. The **wiring**
+(macos-notify on `Stop` only) is declared in `claude/.claude/settings.seed.json`
+and lands in the app-managed `~/.claude/settings.json` at bootstrap. The model +
+bootstrap step (`cp seed → settings.json`, supacode injects its hooks live, fold
+intentional changes back into the seed) are described in `claude/README.md` — not
+duplicated here.
 
-## Erststart nach dem Merge
+## First start after the merge
 
 ```sh
 cd ~/dotfiles && task setup
 ```
 
-Dann eine frische Zellij-Session starten (zellaude/Layout laden beim Start).
-`settings.json` per seed bootstrappen, falls nötig (siehe `claude/README.md`).
+Then start a fresh Zellij session (zellaude/layout load at start). Bootstrap
+`settings.json` from the seed if needed (see `claude/README.md`).

--- a/supacode/README.md
+++ b/supacode/README.md
@@ -1,47 +1,46 @@
 # supacode
 
-Stow-Package für [supacode](https://supacode.sh/) — native macOS-GUI-App auf Basis von
-*libghostty*, die mehrere Coding-Agents parallel in isolierten git-worktrees orchestriert.
-Voraussetzung: macOS 26 Tahoe.
+Stow package for [supacode](https://supacode.sh/) — a native macOS GUI app built on
+*libghostty* that orchestrates several coding agents in parallel in isolated git
+worktrees. Requires macOS 26 Tahoe.
 
-## Integrationsmodell: supacode *über* zellij, nicht statt zellij
+## Integration model: supacode *on top of* zellij, not instead of it
 
-Tabs/Panes laufen weiterhin ausschließlich über zellij. supacode übernimmt nur die Ebene
-darüber:
+Tabs/panes still run exclusively through zellij. supacode only owns the layer above:
 
-| Ebene | Tool | Verantwortung |
+| Layer | Tool | Responsibility |
 |---|---|---|
-| Orchestrierung | **supacode** | Welcher Worktree / welcher Agent? Parallele Agents, PR-Status, Notifications |
-| Multiplexing *innerhalb* eines Worktrees | **zellij** | Tabs + Panes + neovim — unverändertes Setup |
+| Orchestration | **supacode** | Which worktree / which agent? Parallel agents, PR status, notifications |
+| Multiplexing *within* a worktree | **zellij** | Tabs + panes + neovim — unchanged setup |
 
-Regel: **ein supacode-Worktree = eine zellij-Session.** supacodes eigene Splits/Tabs werden
-nicht genutzt. Konfliktfrei, weil supacode Cmd-basiert ist und zellij unter `Ctrl-g` läuft.
+Rule: **one supacode worktree = one zellij session.** supacode's own splits/tabs are
+not used. Conflict-free, because supacode is Cmd-based and zellij runs under `Ctrl-g`.
 
-Das `templates/supacode.json` setzt das um: `setupScript`/`runScript` hängen sich beim
-Worktree-Erstellen bzw. per `⌘R` in eine nach dem Worktree benannte zellij-Session, der
-`archiveScript` räumt sie beim Archivieren wieder ab.
+`templates/supacode.json` implements this: `setupScript`/`runScript` attach — on
+worktree creation or via `⌘R` — to a zellij session named after the worktree, and
+`archiveScript` tears it down again on archiving.
 
-## Terminal-Config kommt aus ghostty
+## Terminal config comes from ghostty
 
-supacode rendert über GhosttyKit und liest die **bestehende ghostty-Config** (Theme, Font,
-Keybinds) — die ist bereits über das `ghostty`-Package gestowt. Es gibt daher hier bewusst
-*keine* eigene Terminal-/Keybind-Config.
+supacode renders through GhosttyKit and reads the **existing ghostty config** (theme,
+font, keybinds) — which is already stowed via the `ghostty` package. There is
+therefore deliberately *no* separate terminal/keybind config here.
 
-## Tastatur (keyboard-only)
+## Keyboard (keyboard-only)
 
-| Aktion | Shortcut |
+| Action | Shortcut |
 |---|---|
-| Command Palette | `⌘P` |
-| Neuer Worktree (Branch + worktree) | `⌘N` |
-| Worktree direkt anspringen | `⌃1` … `⌃0` |
-| Nächster / vorheriger Worktree | `⌃⌘↓` / `⌃⌘↑` |
-| Run-/Setup-Script starten / stoppen | `⌘R` / `⌘.` |
-| Sidebar togglen | `⌘[` |
-| PRs öffnen | `⌃⌘G` |
+| Command palette | `⌘P` |
+| New worktree (branch + worktree) | `⌘N` |
+| Jump straight to a worktree | `⌃1` … `⌃0` |
+| Next / previous worktree | `⌃⌘↓` / `⌃⌘↑` |
+| Start / stop run/setup script | `⌘R` / `⌘.` |
+| Toggle sidebar | `⌘[` |
+| Open PRs | `⌃⌘G` |
 
-`⌃1`–`⌃0` greift supacode auf App-Ebene ab, *bevor* zellij sie sieht. Da zellijs
-Tab-Navigation unter dem `Ctrl-g`-Leader liegt (nicht rohes `Ctrl+Ziffer`), kollisionsfrei —
-beim ersten Test einmal verifizieren.
+`⌃1`–`⌃0` is intercepted by supacode at the app level *before* zellij sees it. Since
+zellij's tab navigation lives under the `Ctrl-g` leader (not raw `Ctrl+digit`), this
+is conflict-free — verify once on first use.
 
 ## Installation / stow
 
@@ -50,36 +49,37 @@ cd ~/dotfiles
 stow -t ~ supacode
 ```
 
-Das verlinkt `~/.supacode/templates/supacode.json` (per-repo-Vorlage, s.u.).
+This links `~/.supacode/templates/supacode.json` (per-repo template, see below).
 
-### settings.json — app-verwaltet, per --adopt einbinden
+### settings.json — app-managed, adopt via --adopt
 
-`~/.supacode/settings.json` ist **kein handgepflegtes File**: die App schreibt dort laufend
-State rein (`global`-Preferences, aber auch maschinenlokales wie `repositories`,
-`repositoryRoots`, `pinnedWorktreeIDs`, Reihenfolgen, lastFocused). Daher nicht vorab von
-Hand schreiben, sondern nach dem ersten Start adoptieren:
+`~/.supacode/settings.json` is **not a hand-maintained file**: the app continuously
+writes state into it (`global` preferences, but also machine-local things like
+`repositories`, `repositoryRoots`, `pinnedWorktreeIDs`, orderings, lastFocused). So
+don't write it by hand up front — adopt it after the first start:
 
 ```sh
-# 1. supacode einmal starten, im GUI Preferences setzen
-#    (Notifications an, Default-Editor = nvim, Update-Channel …), dann beenden.
-# 2. Die von der App erzeugte settings.json ins Package ziehen + zurückverlinken:
+# 1. Start supacode once, set preferences in the GUI
+#    (notifications on, default editor = nvim, update channel …), then quit.
+# 2. Pull the settings.json the app created into the package + relink it:
 cd ~/dotfiles
 stow -t ~ --adopt supacode
-# 3. git diff prüfen: nur portable Keys behalten, maschinenlokalen State ggf. zurücksetzen.
+# 3. Check git diff: keep only portable keys, reset machine-local state if needed.
 git -C ~/dotfiles add -p supacode
 ```
 
-Hinweis: Da die App durch den Symlink hindurch schreibt, dirtyt sie das Repo bei Nutzung.
-Vor dem Commit gezielt `git add -p` nutzen und maschinenlokale Keys auslassen.
+Note: because the app writes through the symlink, it dirties the repo during use.
+Use `git add -p` before committing and leave out machine-local keys.
 
-## Per-repo Setup (zellij-Integration)
+## Per-repo setup (zellij integration)
 
-Die zellij-Anbindung gehört pro Projekt in eine `supacode.json` im jeweiligen Repo-Root
-(nicht ins dotfiles-Repo). Vorlage liegt unter `~/.supacode/templates/supacode.json`:
+The zellij binding belongs per project in a `supacode.json` at the respective repo
+root (not in the dotfiles repo). The template lives at
+`~/.supacode/templates/supacode.json`:
 
 ```sh
-cp ~/.supacode/templates/supacode.json /pfad/zum/projekt/supacode.json
+cp ~/.supacode/templates/supacode.json /path/to/project/supacode.json
 ```
 
-Anschließend `setupScript`/`runScript`/`openActionID` pro Projekt anpassen (z. B. zusätzlich
-`pnpm install` im setupScript).
+Then adjust `setupScript`/`runScript`/`openActionID` per project (e.g. add
+`pnpm install` in the setupScript).


### PR DESCRIPTION
Adds `docs/getting-started.md` (working model, daily flow, nvim + zellij shortcuts, Hyper/MEH) and translates `docs/zellij-workflow.md` + `supacode/README.md` to English.

Closes #55