### PR TITLE
feat(claude): per-tab Claude status via zellij-attention hooks

### DIFF
--- a/claude/.claude/settings.seed.json
+++ b/claude/.claude/settings.seed.json
@@ -32,6 +32,22 @@
             "type": "command",
             "command": "bash ~/.claude/hooks/macos-notify.sh",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "[ -n \"$ZELLIJ_PANE_ID\" ] && zellij pipe --name \"zellij-attention::completed::$ZELLIJ_PANE_ID\" || true",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$ZELLIJ_PANE_ID\" ] && zellij pipe --name \"zellij-attention::waiting::$ZELLIJ_PANE_ID\" || true",
+            "timeout": 5
           }
         ]
       }


### PR DESCRIPTION
Wire Notification→⏳ and Stop→✅ to the zellij-attention plugin via `zellij pipe` (guarded by $ZELLIJ_PANE_ID). Per-tab Claude status in the compact bar, no custom bar.

Closes #61