### PR TITLE
feat(zellij): review tab on compact bar + review alias

### DIFF
--- a/zellij/.config/zellij/layouts/review.kdl
+++ b/zellij/.config/zellij/layouts/review.kdl
@@ -1,10 +1,10 @@
 // Review layout: nvim as the reading/review surface, Claude Code writing beside
-// it, a shell for gates below. One tab per Claude session; open this as a tab
-// with:  zellij action new-tab --layout review  (aliased to `review` in .zshrc).
-// Uses the zellaude bar to match default_layout (Claude status per tab).
+// it, a shell for gates below. Open with:  review  (alias in .zshrc) or
+// `zellij action new-tab --layout review`. Uses the built-in compact bar to match
+// default_layout; the zellij-attention plugin badges this tab too (⏳/✅).
 layout {
     pane size=1 borderless=true {
-        plugin location="file:~/.config/zellij/plugins/zellaude.wasm"
+        plugin location="compact-bar"
     }
     pane split_direction="vertical" {
         // Left: read the diff. In nvim use <leader>gdm to review the whole

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -73,6 +73,9 @@ setopt hist_ignore_space
 alias repos="cd ~/repos"
 alias vim="nvim"
 
+# Open a review tab: nvim (diff/review) | Claude Code | shell, with the compact bar.
+alias review="zellij action new-tab --layout review --name review"
+
 # Open Second Brain vault in nvim (cwd = vault root, args are relative paths)
 sb() {
   (cd "$HOME/Library/Mobile Documents/com~apple~CloudDocs/Second Brain" && nvim "$@")


### PR DESCRIPTION
review.kdl uses the built-in compact bar (not the reverted zellaude bar) and adds a `review` alias to open the nvim | claude | shell tab.

Closes #63