### PR TITLE
feat(zellij): Ctrl-e opens nvim diff pane beside Claude

### DIFF
--- a/zellij/.config/zellij/config.kdl
+++ b/zellij/.config/zellij/config.kdl
@@ -146,6 +146,15 @@ keybinds clear-defaults=true {
         bind "Alt o" { MoveTab "right"; }
         bind "Ctrl q" { Quit; }
 
+        // Ctrl-e: open nvim beside the current pane showing the session's diff
+        // (working tree). In nvim, <leader>gdm reviews the branch vs origin/main.
+        bind "Ctrl e" {
+            NewPane "right" {
+                command "nvim"
+                args "-c" "DiffviewOpen"
+            }
+        }
+
         // Plugin shortcuts
         bind "Ctrl y" {
             LaunchOrFocusPlugin "file:~/.config/zellij/plugins/zellij-forgot.wasm" {


### PR DESCRIPTION
Ctrl-e (global) opens a new pane to the right running nvim with DiffviewOpen (working tree) — the session's changes, one keystroke, no review tab.

Closes #65