### PR TITLE
feat(zellij): Ctrl-e nvim diff pane takes 2/3 width

### DIFF
--- a/zellij/.config/zellij/config.kdl
+++ b/zellij/.config/zellij/config.kdl
@@ -152,6 +152,7 @@ keybinds clear-defaults=true {
         bind "Ctrl e" {
             Run "zsh" "-c" "$HOME/bin/zj-diff" {
                 direction "Right"
+                size "67%"
             }
         }
 


### PR DESCRIPTION
Add size 67% to the Ctrl-e Run block: nvim 2/3, Claude 1/3.

Closes #69