### PR TITLE
feat(agents): severity × basis evidence axis in finding contracts

### DIFF
--- a/claude/.claude/agents/decision-devil.md
+++ b/claude/.claude/agents/decision-devil.md
@@ -19,7 +19,7 @@ You attack only your assigned option. You do not argue for any alternative — p
 ## What to Produce
 
 - **The strongest case against**: the core reason this option is the wrong call, even at its best.
-- **Failure conditions**: the specific circumstances under which this option goes wrong — each with the causal mechanism, not a bare assertion.
+- **Failure conditions**: the specific circumstances under which this option goes wrong — each with the causal mechanism, not a bare assertion. Mark each condition's **basis** — `OBSERVED` (verified in the repo/data, cite it), `HYPOTHESIS` (your inference), or `RECALLED` (general knowledge). Do not dress a hypothesised risk as OBSERVED; the judge discounts unverified risks, and an inflated basis is how a weak objection sinks a good option.
 - **Hidden and downstream costs**: costs the option's advocates tend to omit — migration, lock-in, operational burden, second-order effects — each with its impact.
 - **Precedent / base rate** where it exists: has this class of choice failed before, and why.
 - **Criteria your case assumes**: if the brief states no criteria, name the criteria your attack treats as decisive — do not silently pick criteria that only this option fails.

--- a/claude/.claude/agents/decision-judge.md
+++ b/claude/.claude/agents/decision-judge.md
@@ -26,7 +26,7 @@ Decide against the decision's stated criteria. If none were given, infer the cri
 - **Decisive factor**: defined for both outcomes — for a pick, the single consideration that most drove the call; for "no clear winner", the factor the options are closest on and the evidence that would separate them. If a decision turns on many small things, say so, but name the largest.
 - **Runners-up**: each other option with the concrete reason it lost — not "weaker", but on which criterion and by how much.
 - **Flip conditions**: what would have to be true (new evidence, a changed constraint, a different weighting) for the recommendation to change. This is what makes the decision revisitable instead of dogmatic.
-- **Confidence**: low / medium / high, honestly reflecting how close the call was.
+- **Confidence**: low / medium / high, honestly reflecting how close the call was. Weight an `OBSERVED` strength or failure condition above a `HYPOTHESIS`/`RECALLED` one; when a recommendation rests mostly on unverified claims, cap confidence and put "verify X" in the flip conditions.
 
 ## Output Format
 

--- a/claude/.claude/agents/decision-steelman.md
+++ b/claude/.claude/agents/decision-steelman.md
@@ -20,7 +20,7 @@ You argue only FOR your assigned option. You do not attack the other options —
 
 - **The strongest case**: why this option is the right call, stated as concretely as possible.
 - **Best conditions**: the circumstances under which this option is clearly correct — name them, so the judge can check whether they hold.
-- **Key strengths**: each real advantage with its concrete impact, not adjectives.
+- **Key strengths**: each real advantage with its concrete impact, not adjectives. Mark each strength's **basis** — `OBSERVED` (verified in the repo/data, cite it), `HYPOTHESIS` (your inference), or `RECALLED` (general knowledge). A strength you cannot ground is `HYPOTHESIS`/`RECALLED`, not a fact; the judge weighs OBSERVED strengths higher, so do not inflate the basis.
 - **Honest cost accounting**: name this option's real costs and downsides, then argue why they are outweighed or acceptable. Do not omit them — an unacknowledged cost the judge finds later sinks your whole case.
 - **Criteria your case assumes**: if the brief states no criteria, name the criteria your case treats as decisive and argue against those explicitly — do not silently pick criteria that flatter this option.
 

--- a/claude/.claude/agents/team-blue.md
+++ b/claude/.claude/agents/team-blue.md
@@ -25,7 +25,7 @@ You receive the plan/diff under review and a list of red findings. If findings a
 For every red finding, take exactly one stance:
 
 - **ACCEPT** — the finding is real. Design a mitigation: what changes, where (file/component), and what invariant it restores. Mitigations must be minimal and concrete — no "add validation everywhere", no speculative frameworks. The simplest change that closes the hole wins.
-- **CONTEST** — the finding does not hold. State the evidence: the code path, guard, constraint, or config that already prevents it. Cite files/lines you verified with Read/Grep. A contest without verified evidence is not allowed — if you cannot verify, ACCEPT or DEFER.
+- **CONTEST** — the finding does not hold. State the evidence: the code path, guard, constraint, or config that already prevents it. Cite files/lines you verified with Read/Grep — this is `OBSERVED`-grade evidence, the only kind that refutes. A contest resting on your own hypothesis, not verified evidence, is not allowed — if you cannot verify, ACCEPT or DEFER. Refuting a red `HYPOTHESIS` still requires *your* OBSERVED counter-evidence, not a symmetric counter-guess.
 - **DEFER** — you cannot resolve it with available information. Name exactly what is missing and who/what could provide it.
 
 ## Output Format

--- a/claude/.claude/agents/team-red.md
+++ b/claude/.claude/agents/team-red.md
@@ -38,6 +38,13 @@ If the input is ambiguous, default to Pre-Mortem Mode and state your assumption.
 
 Produce all five sections. If a section has no findings, write "None found — [one sentence explaining what you checked and why it appears clean]." Do not skip sections.
 
+Tag every finding with two independent axes:
+
+- **severity** — impact if the finding is true: `critical | high | medium | low`.
+- **basis** — how you know it: `OBSERVED` (you verified it in the code/spec with Read/Grep — cite file:line), `HYPOTHESIS` (a reasoned inference you could not confirm), `RECALLED` (from general knowledge, not this artifact), `ABSENT` (the thing that should exist is missing).
+
+The axes are orthogonal. **Uncertainty rides the basis axis, never the severity axis** — a plausible critical bug you could not confirm is `critical | HYPOTHESIS`, not a downgraded "medium". Any finding whose basis is not `OBSERVED` carries a `Resolve:` line naming the single check that would settle it (a command to run, a file to read, a search to exhaust).
+
 ---
 
 ## Mode: [Pre-Mortem | Security-Mindset]
@@ -46,19 +53,19 @@ Produce all five sections. If a section has no findings, write "None found — [
 
 What is taken for granted without being stated? What "obvious" truths could be wrong? What does the design only work if it is true?
 
-- [finding: state the assumption, then state what breaks if it is false]
+- [finding | severity | basis: state the assumption, then state what breaks if it is false — `Resolve:` if basis != OBSERVED]
 
 ### 2. Attack Vectors
 
 How does a malicious or hostile input, user, peer service, or compromised dependency cause this to fail or behave incorrectly?
 
-- [finding: attacker capability → exploit → impact]
+- [finding | severity | basis: attacker capability → exploit → impact — `Resolve:` if basis != OBSERVED]
 
 ### 3. Edge Cases / Invariant Violations
 
 What inputs or states were not modeled? Check: null/nil/empty, Unicode/encoding, integer overflow/underflow, timeout/partial failure, race conditions, replay, boundary values, schema mismatch, rollback.
 
-- [finding: input or state → failure mode]
+- [finding | severity | basis: input or state → failure mode — `Resolve:` if basis != OBSERVED]
 
 ### 4. Pre-Mortem Failures
 

--- a/claude/.claude/agents/team-white.md
+++ b/claude/.claude/agents/team-white.md
@@ -14,6 +14,8 @@ You are the White Cell — the referee of a red/blue wargame. You do not attack,
 
 Red exaggerates by design; blue defends by design. Neither is authority. When they disagree on a fact, you verify it yourself with Read/Grep — a ruling based on an unverified claim from either side is a bad ruling.
 
+Each red finding carries a **basis** (OBSERVED / HYPOTHESIS / RECALLED / ABSENT). Use it: an `OBSERVED` finding cites verified evidence and needs a substantive refutation to become REFUTED; a `HYPOTHESIS` or `RECALLED` finding you resolve yourself before ruling (run its `Resolve:` check) — do not rule REAL on an unresolved hypothesis you *could* have checked, and do not rule REFUTED merely because it was "only" a hypothesis. Basis never changes a finding's severity — a critical HYPOTHESIS stays critical.
+
 ## Input
 
 You receive the plan/diff under review, the red findings of this round, and the blue defense. If either side's output is missing, output exactly: `Incomplete round: missing [red findings | blue defense]. No adjudication possible.` and stop.

--- a/claude/.claude/workflows/decision.js
+++ b/claude/.claude/workflows/decision.js
@@ -32,8 +32,8 @@ const FOR_SCHEMA = {
       type: 'array',
       items: {
         type: 'object',
-        required: ['point', 'impact'],
-        properties: { point: { type: 'string' }, impact: { type: 'string' } },
+        required: ['point', 'impact', 'basis'],
+        properties: { point: { type: 'string' }, impact: { type: 'string' }, basis: { enum: ['OBSERVED', 'HYPOTHESIS', 'RECALLED'] } },
       },
     },
     acknowledgedCosts: { type: 'array', items: { type: 'string' } },
@@ -49,8 +49,8 @@ const AGAINST_SCHEMA = {
       type: 'array',
       items: {
         type: 'object',
-        required: ['condition', 'mechanism', 'outcome'],
-        properties: { condition: { type: 'string' }, mechanism: { type: 'string' }, outcome: { type: 'string' } },
+        required: ['condition', 'mechanism', 'outcome', 'basis'],
+        properties: { condition: { type: 'string' }, mechanism: { type: 'string' }, outcome: { type: 'string' }, basis: { enum: ['OBSERVED', 'HYPOTHESIS', 'RECALLED'] } },
       },
     },
     hiddenCosts: { type: 'array', items: { type: 'string' } },
@@ -99,13 +99,15 @@ const cases = await parallel(
       () =>
         agent(
           `${CTX}\n\nBuild the strongest HONEST case FOR this option only: "${opt}". No strawmen, no fabricated benefits, ` +
-            `acknowledge real costs. If no criteria were given, name the criteria your case assumes matter.`,
+            `acknowledge real costs. Mark each strength's basis: OBSERVED (verified in the repo/data — cite it), HYPOTHESIS (your inference), or RECALLED (general knowledge). ` +
+            `If no criteria were given, name the criteria your case assumes matter.`,
           { agentType: 'decision-steelman', label: `for:${opt}`, phase: 'Argue', schema: FOR_SCHEMA },
         ).catch(() => null),
       () =>
         agent(
           `${CTX}\n\nBuild the strongest HONEST case AGAINST the best version of this option only: "${opt}". ` +
-            `Attack the steelman, not a strawman. Propose no alternative. If no criteria were given, name the criteria your case assumes matter.`,
+            `Attack the steelman, not a strawman. Propose no alternative. Mark each failure condition's basis: OBSERVED (verified in the repo/data — cite it), HYPOTHESIS (your inference), or RECALLED (general knowledge). ` +
+            `If no criteria were given, name the criteria your case assumes matter.`,
           { agentType: 'decision-devil', label: `against:${opt}`, phase: 'Argue', schema: AGAINST_SCHEMA },
         ).catch(() => null),
     ]).then(([forCase, againstCase]) => ({ option: opt, forCase, againstCase })),
@@ -135,6 +137,7 @@ const verdict = await agent(
       ? `This is a go/no-go: treat the status quo / do-nothing as the runner-up baseline. `
       : `Give runners-up with the criterion each lost on. `) +
     `Weigh by magnitude on the criteria, NOT by the number of strengths or failure conditions, and do not favor option order. ` +
+    `Weight an OBSERVED point above a HYPOTHESIS or RECALLED one; a decision that rests mostly on unverified (HYPOTHESIS/RECALLED) claims caps confidence and belongs in the flip conditions. ` +
     `Name the decisive factor (for a pick: what drove it; for no clear winner: what options are closest on / the evidence needed) and the flip conditions.`,
   { agentType: 'decision-judge', label: 'judge', schema: DECISION_SCHEMA },
 )

--- a/claude/.claude/workflows/wargame.js
+++ b/claude/.claude/workflows/wargame.js
@@ -26,12 +26,14 @@ const FINDINGS_SCHEMA = {
       type: 'array',
       items: {
         type: 'object',
-        required: ['id', 'title', 'detail', 'severity'],
+        required: ['id', 'title', 'detail', 'severity', 'basis'],
         properties: {
           id: { type: 'string' },
           title: { type: 'string' },
           detail: { type: 'string' },
           severity: { enum: ['low', 'medium', 'high', 'critical'] },
+          basis: { enum: ['OBSERVED', 'HYPOTHESIS', 'RECALLED', 'ABSENT'] },
+          resolve: { type: 'string' },
         },
       },
     },


### PR DESCRIPTION
## What

Adopts nosmoth `reviewer-contract.md`'s two-axis idea across the adversarial + dialectic fleets: separate a finding's **severity** (impact if true) from its **basis** (how it is known), so uncertainty stops deflating severity.

### wargame fleet
- `team-red`: every finding is tagged `severity | basis` where basis ∈ `OBSERVED / HYPOTHESIS / RECALLED / ABSENT`, with a `Resolve:` line on any non-OBSERVED basis. Explicit rule: **uncertainty rides the basis axis at full severity** — a plausible-but-unconfirmed critical is `critical | HYPOTHESIS`, never a downgraded medium.
- `wargame.js` `FINDINGS_SCHEMA`: `basis` enum now required, optional `resolve`.
- `team-white`: weighs basis in rulings — resolves a HYPOTHESIS itself before ruling, needs substantive refutation to REFUTE an OBSERVED finding, and never lets basis change severity.
- `team-blue`: CONTEST evidence named as `OBSERVED`-grade; refuting a red HYPOTHESIS still needs the defender's own observed counter-evidence, not a counter-guess.

### decision fleet
- `decision-steelman` strengths and `decision-devil` failure conditions each carry a `basis` (OBSERVED/HYPOTHESIS/RECALLED); schemas (`FOR_SCHEMA`, `AGAINST_SCHEMA`) require it.
- `decision-judge` weights OBSERVED claims above HYPOTHESIS/RECALLED and caps confidence when a call rests mostly on unverified claims (flip-condition = "verify X").
- Prose and JSON schema kept in parity (both paths carry the axis), preserving the #42 invariant.

Both workflows syntax-check as async function bodies.

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)