### PR TITLE
ci: check reference and agent-citation integrity

### DIFF
--- a/.github/workflows/harness-ci.yml
+++ b/.github/workflows/harness-ci.yml
@@ -52,3 +52,30 @@ jobs:
             fi
           done
           exit $fail
+
+      - name: Check harness-internal file references resolve
+        # backtick-cited paths into the harness's own tree must exist. reviewee-context
+        # paths (spec/, plan.md, AGENTS.md) are the reviewed project's, not ours — excluded.
+        run: |
+          cd claude/.claude
+          fail=0
+          for ref in $(grep -rhoE '`(references|rules|hooks|agents|skills|workflows)/[A-Za-z0-9_./-]+`' \
+                       agents skills workflows references 2>/dev/null | tr -d '`' | sort -u); do
+            if [ ! -e "$ref" ]; then
+              echo "::error::dangling harness reference '$ref' — file does not exist"
+              fail=1
+            fi
+          done
+          exit $fail
+
+      - name: Check agent citations in skills resolve
+        run: |
+          cd claude/.claude
+          fail=0
+          for a in $(grep -rhoE '`(team|decision)-[a-z]+`' skills 2>/dev/null | tr -d '`' | sort -u); do
+            if [ ! -f "agents/$a.md" ]; then
+              echo "::error::skill cites agent '$a' with no agents/$a.md"
+              fail=1
+            fi
+          done
+          exit $fail


### PR DESCRIPTION
## What

Two static checks added to `harness-ci`, closing the two failure classes this session kept hitting manually:

1. **Dead harness reference check** — every backtick-cited `references/|rules/|hooks/|agents/|skills/|workflows/…` path in agents/skills/workflows/references must resolve. This is exactly the `rules/*` / `references/*` dangling-pointer class in team-red that #20 fixed by hand. Reviewee-context paths (`spec/`, `plan.md`, `AGENTS.md`) are deliberately excluded — those belong to the reviewed project, not our tree.
2. **Agent-citation check** — every backtick `team-*` / `decision-*` name cited in a SKILL must resolve to `agents/<name>.md`, so a renamed/removed agent can't leave a skill pointing at nothing.

Both dry-run green against current main.

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)