### PR TITLE
fix(hooks): declare and CI-test jq-absence degradation

### DIFF
--- a/.github/workflows/harness-ci.yml
+++ b/.github/workflows/harness-ci.yml
@@ -79,3 +79,33 @@ jobs:
             fi
           done
           exit $fail
+
+      - name: Hook jq-absence contract
+        # run each jq-using hook under a PATH with no jq, assert it degrades to its
+        # declared `# no-jq:` class (fail-open → exit 0) instead of crashing
+        run: |
+          cd claude/.claude/hooks
+          stub=$(mktemp -d)
+          for b in bash sh env printf echo grep sed cat tr sort cut git basename dirname head tail awk mktemp rm ln timeout ps; do
+            p=$(command -v "$b" 2>/dev/null) || continue
+            case "$p" in /*) ln -s "$p" "$stub/$b" ;; esac  # real binaries only; builtins need no PATH entry
+          done
+          # jq deliberately not linked into $stub
+          fail=0
+          probe() { printf '{"hook_event_name":"Stop","cwd":"/tmp","tool_input":{"command":"%s"}}' "$1"; }
+          check() {
+            hook=$1; input=$2; want=$3
+            PATH="$stub" bash "$hook" >/dev/null 2>&1 <<<"$input"; rc=$?
+            decl=$(sed -nE 's/^# no-jq: (fail-open|fail-closed).*/\1/p' "$hook" | head -1)
+            if [ "$decl" = fail-open ] && [ "$rc" -ne 0 ]; then
+              echo "::error file=$hook::declared no-jq: fail-open but exited $rc without jq"; fail=1
+            elif [ "$decl" = fail-closed ] && [ "$rc" -eq 0 ]; then
+              echo "::error file=$hook::declared no-jq: fail-closed but exited 0 without jq"; fail=1
+            elif [ -z "$decl" ]; then
+              echo "::error file=$hook::uses jq but has no '# no-jq:' declaration"; fail=1
+            fi
+          }
+          check context-guard.sh "$(probe 'kubectl delete pod x --context=prod')"
+          check worktree-guard.sh "$(probe 'git commit -m x')"
+          check macos-notify.sh "$(probe '')"
+          exit $fail

--- a/claude/.claude/hooks/THREAT-MODEL.md
+++ b/claude/.claude/hooks/THREAT-MODEL.md
@@ -67,3 +67,11 @@ defeat them — every guard is bypassable by a shell trick (see Shared non-goals
 - The guards cover four cluster CLIs and git; every other tool (`rm`, `curl | sh`,
   arbitrary Bash) runs unguarded. See the README settings section for the blast
   radius of the skip-prompt flags.
+- **No jq → guards go inert (fail-open).** `context-guard` and `worktree-guard` parse
+  the tool payload with `jq`; without it the command can't be read, so both do
+  nothing and the command proceeds — including a mutating cluster command that
+  `context-guard` would otherwise block. The "Fail-closed" posture is therefore
+  conditional on jq being present (it is, on the target machines: macOS ships
+  `/usr/bin/jq`). Each hook declares this with a `# no-jq: fail-open` header, and
+  `harness-ci` runs every hook under a jq-less PATH to prove it degrades to its
+  declared class rather than crashing.

--- a/claude/.claude/hooks/context-guard.sh
+++ b/claude/.claude/hooks/context-guard.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 # PreToolUse(Bash) guard: block mutating cluster commands against non-allowed contexts.
 # Convention: local playground contexts are always allowed; every remote context must
-# be listed (glob per line, # = comment) in ~/.claude/allowed-contexts. Fail-closed:
-# a mutating command whose target context cannot be resolved or is not allowed is blocked.
+# be listed (glob per line, # = comment) in ~/.claude/allowed-contexts. Fail-closed
+# once the command parses: a mutating command whose target context cannot be resolved
+# or is not allowed is blocked.
+#
+# no-jq: fail-open — without jq the command cannot be parsed, so the guard is inert
+# and the mutating command runs. The Fail-closed guarantee holds only when jq is
+# present (it is, on the target machines). See hooks/THREAT-MODEL.md.
 #
 # Covered: kubectl, helm, talosctl, argocd. Target context comes from explicit
 # --context/--kube-context flags, else the current context of the matching tool.

--- a/claude/.claude/hooks/macos-notify.sh
+++ b/claude/.claude/hooks/macos-notify.sh
@@ -2,6 +2,9 @@
 # macos-notify.sh — surface Claude Code Notification/Stop events as macOS
 # banners, replacing supacode's agent presence badges. No-op inside supacode
 # (its own hooks own presence there) so notifications never fire twice.
+#
+# no-jq: fail-open — without jq the hook exits 0 (silent no-op); a notification is
+# cosmetic, never worth aborting a Stop/Notification event.
 set -euo pipefail
 
 # Skip inside supacode. SUPACODE_SOCKET_PATH is injected by its shell

--- a/claude/.claude/hooks/worktree-guard.sh
+++ b/claude/.claude/hooks/worktree-guard.sh
@@ -8,6 +8,9 @@
 # checked against the repo at each -C path and (for a flagless commit|push) the
 # session cwd. Every commit|push target in a compound command must clear the guard.
 # Shell tricks (cd first, aliases, wrappers) are not caught — safety net, not a wall.
+#
+# no-jq: fail-open — without jq the command cannot be parsed, so the guard is inert
+# and the commit/push proceeds. Consistent with the best-effort posture above.
 set -euo pipefail
 
 payload=$(cat)


### PR DESCRIPTION
## What

From nosmoth's `# no-jq:` header + `jq-absence.test.sh`:

- Each jq-using hook now declares `# no-jq: fail-open` — `context-guard`/`worktree-guard` go inert without jq (command can't be parsed → proceeds); `macos-notify` exits 0 (already jq-robust since #32).
- `context-guard`'s header no longer claims an unconditional "Fail-closed" — it's "Fail-closed once the command parses", with the jq caveat spelled out. THREAT-MODEL documents that both guards degrade to fail-open without jq (jq is present on the target machines: macOS ships `/usr/bin/jq`).
- `harness-ci` gains a **jq-absence contract** step: it builds a PATH with every needed binary except jq, runs each hook, and asserts it matches its declared class (fail-open → exit 0), and flags any jq-using hook with no `# no-jq:` declaration. Verified locally with a clean stub.

## Deliberately out of scope (noted in the issue)

Not porting nosmoth's `tool-error-contract` JSON (our block messages are German prose shown to the user, not parsed by a parent agent) or the realpath-both-paths / metachar-prefilter idioms (our guards have no path allowlist). Those pay off only at that harness's scale.

## Merge note

Touches `harness-ci.yml`, as does #78 — merge #78 first; this rebases cleanly on top.

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)