### PR TITLE
feat(nvim): make Neovim discoverable to the Claude CLI from startup

### DIFF
--- a/nvim/.config/nvim/lua/core/options.lua
+++ b/nvim/.config/nvim/lua/core/options.lua
@@ -57,6 +57,18 @@ vim.api.nvim_create_autocmd({ 'FocusGained', 'BufEnter' }, {
     end,
 })
 
+-- Claude Code editiert Dateien auf Platte; ohne das bleiben offene Buffer veraltet
+vim.opt.autoread = true
+vim.api.nvim_create_autocmd({ 'FocusGained', 'BufEnter', 'TermClose', 'TermLeave' }, {
+    group = vim.api.nvim_create_augroup('reload_on_external_change', { clear = true }),
+    callback = function()
+        -- nicht im Command-Line-Fenster, dort ist checktime verboten
+        if vim.fn.getcmdwintype() == '' then
+            vim.cmd.checktime()
+        end
+    end,
+})
+
 vim.api.nvim_create_autocmd({ 'FocusLost', 'VimLeavePre' }, {
     group = vim.api.nvim_create_augroup('zellij_normal', { clear = true }),
     callback = function()

--- a/nvim/.config/nvim/lua/plugins/ai/claudecode.lua
+++ b/nvim/.config/nvim/lua/plugins/ai/claudecode.lua
@@ -1,28 +1,45 @@
 return {
   'coder/claudecode.nvim',
   dependencies = { 'folke/snacks.nvim' }, -- optional, aber empfohlen
+  -- mit nur `keys` laedt das Plugin erst beim Tastendruck: der <C-.>-Pfad geht dann,
+  -- aber bis dahin gibt es kein ~/.claude/ide/*.lock -- eine unabhaengig gestartete
+  -- claude-CLI (zellij-Pane, Shell) findet nvim also nicht. lazy=false macht nvim
+  -- ab dem Start auffindbar.
+  lazy = false,
+  init = function()
+    local wk_ok, wk = pcall(require, 'which-key')
+    if wk_ok then
+      wk.add { { '<leader>a', group = 'AI / Claude Code' } }
+    end
+  end,
   opts = {
-    -- Server
+    -- Server: muss beim Start laufen, sonst kein ~/.claude/ide/<port>.lock
     auto_start = true,
     log_level = 'warn',
 
-    -- Terminal: snacks (wie dein bisheriges opencode-Setup)
+    -- nach dem Senden einer Selektion direkt im Claude-Fenster weiterschreiben
+    focus_after_send = true,
+
     diff_opts = {
       layout = 'vertical',
     },
 
-terminal = {
+    terminal = {
       provider = 'snacks',
-      snacks = {
-        auto_insert = true,
-        win = {
-          -- position = 'right', -- 'left', 'right', 'bottom', 'float'
-        },
+      -- Worktree-Workflow: Claude soll im Repo-Root arbeiten, nicht im Buffer-Verzeichnis
+      git_repo_cwd = true,
+      -- Sidebar rechts wie im review-Layout; per <C-.> / <leader>ai umschaltbar,
+      -- also nicht permanent (auto_insert ist Top-Level und schon default true)
+      snacks_win_opts = {
+        position = 'right',
+        width = 0.42,
       },
     },
   },
   keys = {
     { '<C-.>', '<cmd>ClaudeCode<cr>', desc = 'Toggle Claude Code', mode = { 'n', 't' } },
+    -- zweiter Weg zum Toggle, auch aus dem <leader>a-Namespace erreichbar
+    { '<leader>ai', '<cmd>ClaudeCode<cr>', desc = 'Claude: Toggle sidebar' },
 
     { '<C-h>', '<cmd>wincmd h<cr>', desc = 'Window left', mode = 't' },
     { '<C-j>', '<cmd>wincmd j<cr>', desc = 'Window down', mode = 't' },

--- a/nvim/.config/nvim/lua/plugins/ai/claudecode.lua
+++ b/nvim/.config/nvim/lua/plugins/ai/claudecode.lua
@@ -40,6 +40,10 @@ return {
     { '<C-.>', '<cmd>ClaudeCode<cr>', desc = 'Toggle Claude Code', mode = { 'n', 't' } },
     -- zweiter Weg zum Toggle, auch aus dem <leader>a-Namespace erreichbar
     { '<leader>ai', '<cmd>ClaudeCode<cr>', desc = 'Claude: Toggle sidebar' },
+    -- ins Claude-Fenster springen, ohne es zuzuklappen
+    { '<leader>af', '<cmd>ClaudeCodeFocus<cr>', desc = 'Claude: Focus window' },
+    -- steht die Bruecke? zeigt Server + Verbindung
+    { '<leader>a?', '<cmd>ClaudeCodeStatus<cr>', desc = 'Claude: Status' },
 
     { '<C-h>', '<cmd>wincmd h<cr>', desc = 'Window left', mode = 't' },
     { '<C-j>', '<cmd>wincmd j<cr>', desc = 'Window down', mode = 't' },

--- a/nvim/.config/nvim/lua/plugins/coding/treesitter.lua
+++ b/nvim/.config/nvim/lua/plugins/coding/treesitter.lua
@@ -97,12 +97,13 @@ return {
           ['[]'] = '@class.outer',
         },
       },
+      -- p wie parameter; <leader>a gehoert der Claude-Code-Namespace
       swap = {
         swap_next = {
-          ['<leader>a'] = '@parameter.inner',
+          ['<leader>p'] = '@parameter.inner',
         },
         swap_previous = {
-          ['<leader>A'] = '@parameter.inner',
+          ['<leader>P'] = '@parameter.inner',
         },
       },
     }

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -73,6 +73,10 @@ setopt hist_ignore_space
 alias repos="cd ~/repos"
 alias vim="nvim"
 
+# git, zellijs EditScrollback und alles andere, was einen Editor aufruft
+export EDITOR=nvim
+export VISUAL=nvim
+
 # Open a review tab: nvim (diff/review) | Claude Code | shell, with the compact bar.
 alias review="zellij action new-tab --layout review --name review"
 


### PR DESCRIPTION
## Why

Most work had moved into the Claude CLI and Neovim had drifted out of the loop.

**Measured, and the nuance matters.** `claudecode.nvim` had `keys = {…}` as its only load trigger, so lazy.nvim deferred it:

| Moment (before) | plugin | server | `~/.claude/ide/*.lock` | consequence |
|---|---|---|---|---|
| nvim started, no key pressed | not loaded | — | none | a `claude` started in a zellij pane or any shell **cannot find** the editor |
| after `<C-.>` / `<leader>a*` | loaded | running | appears | works — this is the path that was in use |

So the in-editor path was fine all along. What was missing is that Neovim only became discoverable *after* pressing a Claude key, which rules out starting `claude` first — the CLI-first direction, which is how most of the work happens.

`lazy = false` makes the server register at startup, so either side can be started first.

## Also fixed

- **A broken config block**: `terminal.snacks = {…}` is not a key this plugin knows — it emitted `Unknown configuration key: snacks` on every load and was silently discarded, so the intended terminal behaviour never applied. `auto_insert` is top-level (already defaults to true); window options belong in `snacks_win_opts`.
- **`autoread` + `checktime`** on focus/enter/term-close — Claude edits files on disk and nothing was reloading open buffers.
- **`EDITOR` / `VISUAL`** were unset, so git and zellij's EditScrollback had no editor.
- **`<leader>a` conflict**: the treesitter parameter swap had claimed bare `<leader>a`/`<leader>A` next to the Claude namespace. It moves to `<leader>p`/`<leader>P` (verified free); Claude keeps `<leader>a` and gets a which-key group.

## Tuned for this workflow

- `git_repo_cwd = true` — Claude starts at the repo root, which matters for the worktree-per-change flow.
- `snacks_win_opts = { position = 'right', width = 0.42 }` — right-hand sidebar mirroring the `review` layout, toggled rather than permanent.
- `focus_after_send = true` — after sending a selection the cursor lands in the Claude window.
- `<leader>ai` as a second toggle inside the `<leader>a` namespace.

## Plugin choice

`claude-chat.nvim` was evaluated: it implements the **same** IDE protocol (WebSocket MCP + `~/.claude/ide/<port>.lock`), so switching would not add the core capability, and running both would conflict over the same lockfile. Staying with `claudecode.nvim` (3004★, 214 forks, active) over a 4★/0-fork project last pushed six weeks ago. Noted for later: `claude-chat.nvim` additionally hosts an in-process MCP server exposing `open_file`, letting Claude open files in editor windows — a capability this plugin lacks, worth revisiting if it proves to matter.

Lua and zsh syntax-checked; plugin verified to load without warnings and to register a lockfile.

Closes #95