### PR TITLE
fix(nvim): give the Claude TUI room and a terminal-mode toggle

### DIFF
--- a/nvim/.config/nvim/lua/plugins/ai/claudecode.lua
+++ b/nvim/.config/nvim/lua/plugins/ai/claudecode.lua
@@ -28,16 +28,17 @@ return {
       provider = 'snacks',
       -- Worktree-Workflow: Claude soll im Repo-Root arbeiten, nicht im Buffer-Verzeichnis
       git_repo_cwd = true,
-      -- Sidebar rechts wie im review-Layout; per <C-.> / <leader>ai umschaltbar,
-      -- also nicht permanent (auto_insert ist Top-Level und schon default true)
-      snacks_win_opts = {
-        position = 'right',
-        width = 0.42,
-      },
+      -- kein snacks_win_opts: der snacks-Default (Float) gibt der Claude-TUI genug
+      -- Spalten. Als rechter Split (42%) in einem schon geteilten zellij-Pane blieben
+      -- zu wenige uebrig und die TUI rendert zerrissen.
     },
   },
   keys = {
     { '<C-.>', '<cmd>ClaudeCode<cr>', desc = 'Toggle Claude Code', mode = { 'n', 't' } },
+    -- robuster Toggle auch AUS dem Claude-Terminal heraus: <C-Space> wird von jedem
+    -- Terminal uebertragen (im Gegensatz zu <C-.>, das das kitty-Protokoll braucht)
+    -- und braucht kein <Esc><Esc>, das sonst in Claudes TUI landet
+    { '<C-Space>', '<cmd>ClaudeCode<cr>', desc = 'Toggle Claude Code', mode = { 'n', 't' } },
     -- zweiter Weg zum Toggle, auch aus dem <leader>a-Namespace erreichbar
     { '<leader>ai', '<cmd>ClaudeCode<cr>', desc = 'Claude: Toggle sidebar' },
     -- ins Claude-Fenster springen, ohne es zuzuklappen


### PR DESCRIPTION
## What

Fixes two problems, one of them a regression I introduced in #96.

**Reverted the sidebar.** `snacks_win_opts = { position = 'right', width = 0.42 }` made Claude's TUI render broken — as a 42% split inside a Neovim window that is itself a zellij pane, too few columns were left: empty regions, stray fragments, a truncated status line, and a left window narrow enough to scroll horizontally and clip code. Dropping the option restores the snacks default float, which has the room the TUI needs. This was the working state before #96; the sidebar looked right on paper and did not survive contact with the actual layout.

**Added `<C-Space>` as a toggle in normal *and* terminal mode.** Closing the window from inside previously meant `<Esc><Esc>` first, and a slow first `<Esc>` lands in Claude's TUI and disturbs the session. `<C-Space>` needs no `<Esc>`, is transmitted by any terminal (unlike `<C-.>`, which depends on the kitty keyboard protocol), and is free in both Neovim and zellij — verified. `<C-.>` stays as-is.

`<leader>*` maps are deliberately not extended to terminal mode: leader is Space, so that would swallow every space typed into Claude.

Verified: `luac -p` clean, and both `<C-Space>` and `<C-.>` confirmed registered as terminal-mode maps.

Closes #98