### PR TITLE
fix(nvim): track telescope releases instead of frozen 0.1.x

### DIFF
--- a/nvim/.config/nvim/lua/plugins/core/telescope.lua
+++ b/nvim/.config/nvim/lua/plugins/core/telescope.lua
@@ -1,7 +1,10 @@
 -- Fuzzy Finder (files, lsp, etc)
 return {
   'nvim-telescope/telescope.nvim',
-  branch = '0.1.x',
+  -- kein branch = '0.1.x': der Branch ist seit 2024-05 eingefroren und ruft
+  -- ts_parsers.ft_to_lang, das nvim 0.12 entfernt hat. Ab v0.2.x nutzt telescope
+  -- die Core-Treesitter-API (get_lang). version = '*' folgt dem letzten Release.
+  version = '*',
   dependencies = {
     'nvim-lua/plenary.nvim',
     -- Fuzzy Finder Algorithm which requires local dependencies to be built.


### PR DESCRIPTION
## Cause (verified upstream, not guessed)

Switching buffers threw `attempt to call field 'ft_to_lang' (a nil value)` from `telescope/previewers/utils.lua:135`.

- Neovim 0.12 removed `vim.treesitter.language.ft_to_lang` (checked locally: nil; `get_lang` exists). This machine runs 0.12.0.
- The spec pinned `branch = '0.1.x'`. That branch's upstream tip **is** the installed commit — `a0bbec2`, 2024-05-24 — and it still calls `ts_parsers.ft_to_lang(ft)`. The branch is frozen, so no amount of updating on that line could ever fix it. A `Lazy update` fetched new commits and then checked out nothing, which is exactly this.
- `v0.2.0` release notes: "drops support for Nvim 0.9 and fixes a number of deprecations on Nvim 0.12", moving treesitter handling to the core API. `v0.2.1` (2025-12-31, current latest release) uses `vim.treesitter.language.get_lang(ft) or ft`.
- Only breaking change in v0.2.0: minimum Neovim 0.10.4 — satisfied.

## Change

`branch = '0.1.x'` → `version = '*'`, so the spec follows released versions (currently v0.2.1) instead of a dead branch.

## Note on applying it

The plugin swap happens on the next `:Lazy update telescope.nvim` / restart, which also rewrites `lazy-lock.json` in the main checkout — that is a separate commit. I deliberately did **not** run the update headlessly: the lazy data dir is shared with the running Neovim session, and swapping the plugin under a live session is not something to do unasked.

Closes #100