### PR TITLE
chore(nvim): bump telescope lockfile to v0.2.2

### DIFF
--- a/nvim/.config/nvim/lazy-lock.json
+++ b/nvim/.config/nvim/lazy-lock.json
@@ -87,7 +87,7 @@
   "telescope-tabs": { "branch": "master", "commit": "62c127346c04c698c0cbd1c1ba945609a0ad10db" },
   "telescope-terraform-doc.nvim": { "branch": "main", "commit": "66987fac94d12704fdfd90b857f4f648e31251c9" },
   "telescope-ui-select.nvim": { "branch": "master", "commit": "6e51d7da30bd139a6950adf2a47fda6df9fa06d2" },
-  "telescope.nvim": { "branch": "0.1.x", "commit": "a0bbec21143c7bc5f8bb02e0005fa0b982edc026" },
+  "telescope.nvim": { "branch": "master", "commit": "5255aa27c422de944791318024167ad5d40aad20" },
   "todo-comments.nvim": { "branch": "main", "commit": "31e3c38ce9b29781e4422fc0322eb0a21f4e8668" },
   "toon.nvim": { "branch": "main", "commit": "91a927532c8c65e7bd7b980d04d9401ea5c419a4" },
   "trouble.nvim": { "branch": "main", "commit": "bd67efe408d4816e25e8491cc5ad4088e708a69a" },


### PR DESCRIPTION
Records the `lazy-lock.json` change from `:Lazy update telescope.nvim`: telescope moves off the frozen `0.1.x` commit (2024-05-24) to **v0.2.2** (`5255aa2`), which resolves the Neovim 0.12 `ft_to_lang` crash from #100.

Verified on the installed copy: `previewers/utils.lua` now uses `vim.treesitter.language.get_lang(ft) or ft`, and `require('telescope')` loads cleanly on 0.12.0.

Closes #102