### PR TITLE
feat(nvim): make Neovim follow Claude into a new worktree

### DIFF
--- a/claude/.claude/skills/pr-flow/SKILL.md
+++ b/claude/.claude/skills/pr-flow/SKILL.md
@@ -40,13 +40,21 @@ Robert hat oft mehrere Sessions parallel → der Hauptcheckout hängt meist auf 
 fremden Feature-Branch mit uncommitteter WIP. Niemals den Hauptcheckout-Branch
 annehmen, wechseln, stashen oder resetten.
 
+Worktrees als **Geschwister-Verzeichnis** anlegen, nicht im Scratchpad: `<repo>.wt/<branch>`
+(Slashes im Branch zu `-`). Ein Scratchpad-Worktree ist beim Session-Ende weg und Robert
+kann dort keinen Editor öffnen — beides ist real passiert.
+
 ```bash
 # Erst die fremde WIP im Hauptcheckout erkennen
 git -C <repo> status -sb
 
 # Dann sauberen Worktree von origin/<ziel> (meist main)
 git -C <repo> fetch origin <ziel>
-git -C <repo> worktree add <tmp-pfad> origin/<ziel> -b <branch>
+git -C <repo> worktree add <repo>.wt/<branch> origin/<ziel> -b <branch>
+
+# Und nvim davon in Kenntnis setzen — sonst haengt es im Hauptcheckout,
+# wo sich die editierten Dateien gar nicht aendern (stiller No-Op ohne nvim)
+wt-open <repo>.wt/<branch>
 ```
 
 Live-Cluster-Aktionen (`sops -d`, `kubectl apply`, …) laufen branch-unabhängig und

--- a/nvim/.config/nvim/init.lua
+++ b/nvim/.config/nvim/init.lua
@@ -1,5 +1,6 @@
 require 'core.options'
 require 'core.keymaps'
+require 'core.rpc'
 
 local lazypath = vim.fn.stdpath 'data' .. '/lazy/lazy.nvim'
 if not (vim.uv or vim.loop).fs_stat(lazypath) then

--- a/nvim/.config/nvim/lua/core/rpc.lua
+++ b/nvim/.config/nvim/lua/core/rpc.lua
@@ -1,0 +1,24 @@
+-- Deterministischer RPC-Socket, damit externe Tools (z. B. Claude nach einem
+-- `git worktree add`) diesem nvim etwas sagen koennen -- siehe zsh/bin/wt-open.
+-- Der Socket ist repo-bezogen: bei mehreren nvims ist so eindeutig, welches
+-- fuer welches Repo zustaendig ist. Ist der Name belegt (zweites nvim im selben
+-- Repo), gewinnt das erste und wir bleiben still.
+
+local root = vim.fs.root(0, '.git')
+if not root then
+    return
+end
+
+local dir = vim.fn.stdpath 'cache' .. '/servers'
+vim.fn.mkdir(dir, 'p')
+
+-- Repo-Pfad -> flacher Dateiname
+local name = root:gsub('^/', ''):gsub('/', '%%')
+local sock = string.format('%s/%s.sock', dir, name)
+
+-- Verwaister Socket eines abgestuerzten nvim: serverstart wuerde daran scheitern.
+if vim.uv.fs_stat(sock) and not pcall(vim.fn.sockconnect, 'pipe', sock, { rpc = true }) then
+    vim.fn.delete(sock)
+end
+
+pcall(vim.fn.serverstart, sock)

--- a/zsh/bin/wt-open
+++ b/zsh/bin/wt-open
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# wt-open — tell the running nvim of a repo to show a worktree in its own tab.
+# Called after `git worktree add` (see the pr-flow skill) so nvim does not stay
+# behind in the main checkout, where the edited files simply do not change.
+#
+# Silent no-op when no nvim listens for that repo: this must never break a
+# worktree workflow. No `set -e` for the same reason.
+#
+# Usage: wt-open <worktree-path>
+
+export PATH="/opt/homebrew/bin:$HOME/bin:$PATH"
+
+target="${1:-}"
+[ -n "$target" ] || { echo "usage: wt-open <worktree-path>" >&2; exit 2; }
+[ -d "$target" ] || { echo "wt-open: no such directory: $target" >&2; exit 2; }
+
+target=$(cd "$target" && pwd -P) || exit 2
+
+# The socket is keyed by the MAIN checkout, not the worktree: that is where the
+# nvim we want to talk to was started. `--git-common-dir` points at the main
+# repo's .git for every worktree.
+common=$(git -C "$target" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || exit 0
+root=$(cd "$common/.." && pwd -P) || exit 0
+
+name=${root#/}
+name=${name//\//%}
+sock="${XDG_CACHE_HOME:-$HOME/.cache}/nvim/servers/${name}.sock"
+[ -S "$sock" ] || exit 0
+
+# Reuse a tab that already sits in this worktree, else open one. Everything in a
+# single expression so it is one round trip.
+expr=$(cat <<LUA
+luaeval('(function(p) for _, t in ipairs(vim.api.nvim_list_tabpages()) do if vim.fn.getcwd(-1, vim.api.nvim_tabpage_get_number(t)) == p then vim.api.nvim_set_current_tabpage(t) return "switched" end end vim.cmd("tabnew") vim.cmd("tcd " .. vim.fn.fnameescape(p)) vim.cmd("edit .") return "opened" end)(_A)', '$target')
+LUA
+)
+
+result=$(nvim --server "$sock" --remote-expr "$expr" 2>/dev/null)
+[ -n "$result" ] && printf 'wt-open: %s tab for %s\n' "$result" "$target"
+exit 0


### PR DESCRIPTION
## Problem

Neovim sits in the main checkout while Claude works in a worktree. Its edits touch *different files on disk*, so nothing appears in open buffers — and `checktime` cannot help, because the main-checkout files genuinely did not change. This is the drift that made Neovim feel disconnected.

## Mechanism (verified end to end, not assumed)

`nvim --listen <sock>` + `nvim --server <sock> --remote-expr` can create a tab with a tab-local cwd, and `claudecode.nvim` resolves its terminal cwd through `vim.fn.getcwd()`, which respects `:tcd`. So a Claude opened in such a tab lands in the worktree.

## Three parts

1. **`lua/core/rpc.lua`** — Neovim listens on a deterministic, **repo-scoped** socket under `stdpath('cache')/servers/`, keyed by repo root so it is unambiguous which instance serves which repo. A stale socket from a crashed instance is probed and removed; a second instance in the same repo loses the race silently.
2. **`zsh/bin/wt-open <path>`** — resolves the socket via `--git-common-dir` (so it works when called with a *worktree* path but the nvim was started in the main checkout), then reuses a tab already sitting in that cwd or opens one. No listener → silent no-op; a worktree workflow must never break because an editor is absent.
3. **`pr-flow`** now calls `wt-open` after `git worktree add`, and specifies worktrees as a **sibling directory** (`<repo>.wt/<branch>`) instead of a scratchpad — a scratchpad worktree vanishes at session end and cannot host an editor. Both failure modes happened for real today: a history rewrite was lost that way.

## Tested

| case | result |
|---|---|
| socket created, keyed on main checkout | `…/servers/Users%robertschneider%dotfiles.sock` |
| `wt-open <worktree>` | opened tab, `getcwd()` = worktree |
| called twice | second switches, tab count stays 2 |
| no nvim listening | exit 0, no output |
| invalid path | clear error, exit 2 |

`bash -n` and `luac -p` clean; harness-ci checks pass locally.

Closes #104