### PR TITLE
fix(nvim): reach nvim from a multi-repo parent folder

### DIFF
--- a/nvim/.config/nvim/lua/core/rpc.lua
+++ b/nvim/.config/nvim/lua/core/rpc.lua
@@ -1,10 +1,14 @@
 -- Deterministischer RPC-Socket, damit externe Tools (z. B. Claude nach einem
 -- `git worktree add`) diesem nvim etwas sagen koennen -- siehe zsh/bin/wt-open.
--- Der Socket ist repo-bezogen: bei mehreren nvims ist so eindeutig, welches
--- fuer welches Repo zustaendig ist. Ist der Name belegt (zweites nvim im selben
--- Repo), gewinnt das erste und wir bleiben still.
+-- Der Socket ist ortsbezogen: bei mehreren nvims ist so eindeutig, welches
+-- wofuer zustaendig ist. Ist der Name belegt (zweites nvim am selben Ort),
+-- gewinnt das erste und wir bleiben still.
+--
+-- Ohne Repo (der Ueberordner mit mehreren Repos darin ist selbst keins) wird auf
+-- das Startverzeichnis gekeyed -- sonst gaebe es fuer genau diesen Fall gar
+-- keinen Kanal. wt-open sucht von einem Repo aus aufwaerts und findet beides.
 
-local root = vim.fs.root(0, '.git')
+local root = vim.fs.root(0, '.git') or vim.uv.cwd()
 if not root then
     return
 end
@@ -12,7 +16,7 @@ end
 local dir = vim.fn.stdpath 'cache' .. '/servers'
 vim.fn.mkdir(dir, 'p')
 
--- Repo-Pfad -> flacher Dateiname
+-- Pfad -> flacher Dateiname
 local name = root:gsub('^/', ''):gsub('/', '%%')
 local sock = string.format('%s/%s.sock', dir, name)
 

--- a/zsh/bin/wt-open
+++ b/zsh/bin/wt-open
@@ -22,10 +22,26 @@ target=$(cd "$target" && pwd -P) || exit 2
 common=$(git -C "$target" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || exit 0
 root=$(cd "$common/.." && pwd -P) || exit 0
 
-name=${root#/}
-name=${name//\//%}
-sock="${XDG_CACHE_HOME:-$HOME/.cache}/nvim/servers/${name}.sock"
-[ -S "$sock" ] || exit 0
+servers="${XDG_CACHE_HOME:-$HOME/.cache}/nvim/servers"
+
+# Walk upward from the main checkout: nvim may have been started in the repo, or
+# in a parent folder holding several repos (that folder is not a repo itself, so
+# it registers under its own path). First socket found wins.
+sock=""
+dir="$root"
+while :; do
+	name=${dir#/}
+	name=${name//\//%}
+	if [ -S "$servers/${name}.sock" ]; then
+		sock="$servers/${name}.sock"
+		break
+	fi
+	case "$dir" in
+	/ | "$HOME") break ;;
+	esac
+	dir=$(dirname "$dir")
+done
+[ -n "$sock" ] || exit 0
 
 # Reuse a tab that already sits in this worktree, else open one. Everything in a
 # single expression so it is one round trip.


### PR DESCRIPTION
## Problem

Verified before changing anything: Neovim started in a folder without `.git` created **no socket at all**. `rpc.lua` called `vim.fs.root(0, '.git')` and returned early on `nil`.

That is the common multi-repo shape — one parent folder holding several repos, each with its own worktrees. In that setup #105 was inert: no channel existed, so `wt-open` did its silent no-op and nothing opened. The parent folder is not itself a repo, which is exactly why it fell through.

## Change

1. **`rpc.lua`** — falls back to the cwd when there is no repo, so a parent-folder instance registers under its own path.
2. **`wt-open`** — walks upward from the repo's main checkout (repo root, then parents, stopping at `$HOME` or `/`) and takes the first socket found. This mirrors what `zj-diff` already does for the same parent-folder shape. The loop's exit test uses `case` rather than `||`/`&&` so shell precedence cannot surprise anyone later.

## Tested

**The case that motivated this** — nvim in the parent folder, worktrees from *two different* repos:

```
socket:  …/servers/private%tmp%ueber-78047.sock     (parent folder, not a repo)
wt-open …/repoA.wt/feat  → opened tab
wt-open …/repoB.wt/feat  → opened tab
tabs: 3
cwds: /tmp/ueber-…  |  /tmp/ueber-…/repoA.wt/feat  |  /tmp/ueber-…/repoB.wt/feat
```

**No regression** on #105's case — nvim inside the repo still keys on the repo root (`Users%robertschneider%dotfiles.sock`) and opens the tab correctly.

`bash -n` and `luac -p` clean; harness-ci checks pass locally.

Closes #106