### PR TITLE
fix(pr-flow): call wt-open by absolute path

### DIFF
--- a/claude/.claude/skills/pr-flow/SKILL.md
+++ b/claude/.claude/skills/pr-flow/SKILL.md
@@ -54,7 +54,7 @@ git -C <repo> worktree add <repo>.wt/<branch> origin/<ziel> -b <branch>
 
 # Und nvim davon in Kenntnis setzen — sonst haengt es im Hauptcheckout,
 # wo sich die editierten Dateien gar nicht aendern (stiller No-Op ohne nvim)
-wt-open <repo>.wt/<branch>
+"$HOME"/bin/wt-open <repo>.wt/<branch>
 ```
 
 Live-Cluster-Aktionen (`sops -d`, `kubectl apply`, …) laufen branch-unabhängig und


### PR DESCRIPTION
`pr-flow` instructed `wt-open <path>`, but `~/bin` is deliberately not on `PATH` — that line was removed together with the session-per-worktree model in `02c91c7`. The call would have failed with `command not found` and Neovim would never have been informed.

Now invoked as `"$HOME"/bin/wt-open`, matching how the `Ctrl e` keybind calls `$HOME/bin/zj-diff`. `~/bin` is a symlink to `dotfiles/zsh/bin`, so the script itself stays current on every merge.

Closes #108