### PR TITLE
feat(nvim): zoom the Claude float from terminal mode

### DIFF
--- a/nvim/.config/nvim/lua/plugins/core/snacks.lua
+++ b/nvim/.config/nvim/lua/plugins/core/snacks.lua
@@ -1,3 +1,31 @@
+-- Vergroessert das aktuelle Float (z. B. das Claude-Terminal) auf fast-Vollbild und
+-- zurueck. Snacks.zen.zoom() taugt dafuer nicht: es legt ein NEUES Zen-Float um den
+-- Buffer und schliesst sich, sobald der Fokus in ein nicht-schwebendes Fenster geht.
+-- Auf einem normalen Fenster fallen wir deshalb auf zoom() zurueck.
+local function toggle_zoom()
+  local win = vim.api.nvim_get_current_win()
+  local cfg = vim.api.nvim_win_get_config(win)
+
+  if cfg.relative == '' then
+    Snacks.zen.zoom()
+    return
+  end
+
+  local saved = vim.w.float_zoom_saved
+  if saved then
+    cfg.width, cfg.height, cfg.row, cfg.col = saved.width, saved.height, saved.row, saved.col
+    vim.w.float_zoom_saved = nil
+  else
+    vim.w.float_zoom_saved = { width = cfg.width, height = cfg.height, row = cfg.row, col = cfg.col }
+    cfg.width = math.max(cfg.width, math.floor(vim.o.columns * 0.95))
+    cfg.height = math.max(cfg.height, math.floor(vim.o.lines * 0.9))
+    cfg.row = math.max(0, math.floor((vim.o.lines - cfg.height) / 2) - 1)
+    cfg.col = math.max(0, math.floor((vim.o.columns - cfg.width) / 2))
+  end
+
+  pcall(vim.api.nvim_win_set_config, win, cfg)
+end
+
 return {
   'folke/snacks.nvim',
   priority = 1000,
@@ -49,6 +77,13 @@ return {
         Snacks.zen.zoom()
       end,
       desc = 'Toggle Zoom',
+    },
+    {
+      -- auch aus dem Terminal-Mode heraus, ohne <Esc><Esc> (das sonst in Claudes TUI landet)
+      '<C-]>',
+      toggle_zoom,
+      desc = 'Toggle Zoom (float or window)',
+      mode = { 'n', 't' },
     },
     {
       '<leader>.',


### PR DESCRIPTION
## Why not rebind `<leader>Z`

`Snacks.zen.zoom()` does not maximise a window: it opens a **new** zen float around the current buffer (`snacks/zen.lua:118`; `zoom` is `zen(opts.zoom)` at :230) and closes itself as soon as focus moves to a non-floating window (:218). Claude runs in a float since #99, so binding that function to a new key would nest floats — not what "make it bigger" means.

## What this does

`<C-]>` in **normal and terminal mode**:
- current window is a float → toggle it between its own size and near-fullscreen (95% × 90%, centred), and back to the exact previous geometry
- current window is a normal split → falls back to `Snacks.zen.zoom()`, so the key stays useful outside floats

`<leader>z` / `<leader>Z` are untouched.

## Key choice

`<C-]>` is free in the Neovim config and in zellij. It shadows built-in tag-jump — checked: there is no tag configuration at all (LSP does that job here), so nothing is lost. Terminal mode matters because the alternative is `<Esc><Esc>` first, and a slow first `<Esc>` lands in Claude's TUI.

## Tested

Against a real float and a real split:

```
start:    40x10 @3,5
zoomed:   76x21 @0,2     (editor 80x24 → 95% x 90%, centred)
back:     40x10 @3,5     (exact restore)
split:    FALLBACK zen.zoom
```

`row`/`col` come back as plain numbers on Neovim 0.12, so no array-quirk handling is needed. `luac -p` clean.

Closes #110