### PR TITLE
fix(nvim): stop auto-resizing the Claude terminal

### DIFF
--- a/nvim/.config/nvim/lua/plugins/ai/claudecode.lua
+++ b/nvim/.config/nvim/lua/plugins/ai/claudecode.lua
@@ -22,6 +22,11 @@ return {
 
     diff_opts = {
       layout = 'vertical',
+      -- Claudes Ink-TUI zeichnet relativ zum Cursor und clearst bei Resize nicht voll,
+      -- da bleiben Reste der alten Breite stehen. Der Plugin-Default verstellt die
+      -- Terminal-Breite rund um Diffs von selbst -- das abschalten. Absichtliches
+      -- Resizen per <C-]> bleibt.
+      auto_resize_terminal = false,
     },
 
     terminal = {


### PR DESCRIPTION
## One variable

`diff_opts.auto_resize_terminal = false`. Nothing else.

## Why

Claude Code is an Ink TUI. Per the plugin's own notes (`terminal/snacks.lua:80-95`) it re-renders relative to the cursor and does not fully clear on resize, so stale rows from the previous width survive — the fragments and duplicated status line in the reported screenshots. `auto_resize_terminal` defaults to **true**, meaning the plugin changes the terminal's width around the diff lifecycle: an automatic, unrequested resize during ordinary work.

This also revises my earlier explanation in #99. I attributed the distortion there to "too few columns" in a 42% split. The same artefact now appears in a float, so width was likely not the cause — unrequested resizing was.

## Deliberately unchanged

`<C-]>` zoom stays. Resizing on purpose is wanted; only the resizing nobody asked for is switched off.

## Verified

Effective config after loading: `auto_resize_terminal=false`, `layout=vertical` untouched, `<C-]>` still mapped. Whether the distortion is gone can only be judged visually — this is a single-variable experiment, not a claimed fix.

Closes #114