### PR TITLE
fix(nvim): zoom only floats, never open one

### DIFF
--- a/nvim/.config/nvim/lua/plugins/core/snacks.lua
+++ b/nvim/.config/nvim/lua/plugins/core/snacks.lua
@@ -1,7 +1,9 @@
 -- Vergroessert das aktuelle Float (z. B. das Claude-Terminal) auf fast-Vollbild und
--- zurueck. Snacks.zen.zoom() taugt dafuer nicht: es legt ein NEUES Zen-Float um den
--- Buffer und schliesst sich, sobald der Fokus in ein nicht-schwebendes Fenster geht.
--- Auf einem normalen Fenster fallen wir deshalb auf zoom() zurueck.
+-- zurueck. Ausschliesslich Floats: auf einem normalen Fenster tut die Taste nichts.
+-- Kein Fallback auf Snacks.zen.zoom() -- das maximiert nicht, sondern OEFFNET ein
+-- neues Zen-Float, was hier als ungewolltes schwebendes Fenster auffiel.
+-- Fuer normale Fenster ist <leader>Z zustaendig.
+--
 -- Richtung kommt aus der GEOMETRIE, nicht aus gemerktem Zustand: claudecode patcht
 -- hide/show/toggle der snacks-Instanz, dabei kann die Fenster-ID wechseln -- ein
 -- window-local gemerkter Wert waere dann weg und der Toggle wuerde nur noch
@@ -14,7 +16,6 @@ local function toggle_zoom()
   local cfg = vim.api.nvim_win_get_config(win)
 
   if cfg.relative == '' then
-    Snacks.zen.zoom()
     return
   end
 
@@ -99,7 +100,7 @@ return {
       -- auch aus dem Terminal-Mode heraus, ohne <Esc><Esc> (das sonst in Claudes TUI landet)
       '<C-]>',
       toggle_zoom,
-      desc = 'Toggle Zoom (float or window)',
+      desc = 'Toggle Zoom (float only)',
       mode = { 'n', 't' },
     },
     {


### PR DESCRIPTION
## Found by use, not by me

`<C-]>` opened a floating pane even with no Claude terminal involved.

## Cause

The mapping fell back to `Snacks.zen.zoom()` on a non-floating window:

```lua
if cfg.relative == '' then
  Snacks.zen.zoom()
  return
end
```

`Snacks.zen.zoom()` does not maximise anything — it **opens a new floating zen window** around the current buffer. So on any ordinary window the key spawned a float. That also explains the `zoom` indicator in the tabline and the duplicated content in the screenshot: the zen float overlays the scene and renders buffer content a second time.

I added that fallback in #111 as an unrequested convenience ("so the key stays useful in splits"). It was the bug. This also means my resize/repaint theory was at best incomplete — the visible artefact had a simpler cause.

## Fix

Remove the fallback. `<C-]>` acts on floats only and is silent otherwise; `desc` corrected to "float only". `<leader>Z` stays the zen-zoom key for normal windows, which is what it was always for.

## Tested

```
normal window: windows before=1, after=1   → opens nothing
float:         40x10 → 76x21 → 40x10        → still toggles both ways
```

Closes #116