### PR TITLE
fix(nvim): zoom splits too, still without opening windows

### DIFF
--- a/nvim/.config/nvim/lua/plugins/core/snacks.lua
+++ b/nvim/.config/nvim/lua/plugins/core/snacks.lua
@@ -1,21 +1,34 @@
--- Vergroessert das aktuelle Float (z. B. das Claude-Terminal) auf fast-Vollbild und
--- zurueck. Ausschliesslich Floats: auf einem normalen Fenster tut die Taste nichts.
--- Kein Fallback auf Snacks.zen.zoom() -- das maximiert nicht, sondern OEFFNET ein
--- neues Zen-Float, was hier als ungewolltes schwebendes Fenster auffiel.
--- Fuer normale Fenster ist <leader>Z zustaendig.
+-- Macht das aktuelle Fenster gross und wieder klein -- Float (z. B. das
+-- Claude-Terminal) wie Split. Es wird dabei NIE ein Fenster geoeffnet:
+-- Snacks.zen.zoom() taugt hier nicht, das maximiert nicht, sondern legt ein neues
+-- Zen-Float an (fiel als ungewolltes schwebendes Fenster auf). <leader>Z bleibt
+-- fuer genau dieses Zen-Verhalten zustaendig.
 --
--- Richtung kommt aus der GEOMETRIE, nicht aus gemerktem Zustand: claudecode patcht
--- hide/show/toggle der snacks-Instanz, dabei kann die Fenster-ID wechseln -- ein
--- window-local gemerkter Wert waere dann weg und der Toggle wuerde nur noch
--- hochzoomen (mit math.max unsichtbar) statt zu verkleinern. Die vorige Groesse ist
--- Komfort, keine Voraussetzung.
+-- Richtung kommt aus der GEOMETRIE bzw. aus winrestcmd, nicht aus gemerktem
+-- Fensterzustand: claudecode patcht hide/show/toggle der snacks-Instanz, dabei kann
+-- die Fenster-ID wechseln -- ein window-local gemerkter Wert waere dann weg und der
+-- Toggle wuerde nur noch hochzoomen statt zu verkleinern.
 local prev = {}
+local restore = {}
 
 local function toggle_zoom()
   local win = vim.api.nvim_get_current_win()
   local cfg = vim.api.nvim_win_get_config(win)
 
+  -- normales Fenster: per winrestcmd maximieren/zurueck, ohne neues Fenster
   if cfg.relative == '' then
+    local tab = vim.api.nvim_get_current_tabpage()
+    if #vim.api.nvim_tabpage_list_wins(tab) == 1 then
+      return
+    end
+    if restore[tab] then
+      vim.cmd(restore[tab])
+      restore[tab] = nil
+    else
+      restore[tab] = vim.fn.winrestcmd()
+      vim.cmd 'wincmd _'
+      vim.cmd 'wincmd |'
+    end
     return
   end
 
@@ -100,7 +113,7 @@ return {
       -- auch aus dem Terminal-Mode heraus, ohne <Esc><Esc> (das sonst in Claudes TUI landet)
       '<C-]>',
       toggle_zoom,
-      desc = 'Toggle Zoom (float only)',
+      desc = 'Toggle Zoom (float or split)',
       mode = { 'n', 't' },
     },
     {


### PR DESCRIPTION
## Symptom

`<C-]>` did nothing. The mapping was registered (verified present in normal *and* terminal mode, snacks loaded) — it fired and returned without acting.

## Cause

#117 removed the `Snacks.zen.zoom()` fallback because it opened an unwanted floating window. Right call, incomplete result: the non-float branch was left doing nothing, so on any ordinary split the key was dead. Two fixes in a row that each solved one half.

## Now

Zoom means "make the current window big", float **or** split, and never opens a window:

- **float** → toggles between ~95%×90% centred and back (unchanged)
- **split** → `winrestcmd()` captures the layout, then `wincmd _` / `wincmd |`; pressing again runs the saved restore command
- **single window** → no-op, nothing to maximise

`<leader>Z` keeps `Snacks.zen.zoom()` for when the zen float *is* what you want.

## Tested — window count never changes

```
SPLIT   h=18 wins=3 → h=35 wins=3 → h=18 wins=3
EINZEL  wins=1      → wins=1                     (no-op)
FLOAT   40x10       → 114x36      → 40x10        wins unchanged
```

Closes #118