### PR TITLE
fix(nvim): skip stale worktrees in the picker

### DIFF
--- a/nvim/.config/nvim/lua/plugins/core/telescope.lua
+++ b/nvim/.config/nvim/lua/plugins/core/telescope.lua
@@ -126,8 +126,19 @@ return {
           return
         end
       end
+      -- VOR dem tabnew pruefen, sonst bleibt bei fehlendem Verzeichnis ein leerer Tab
+      -- stehen und :tcd wirft einen Lua-Fehler (E344).
+      if vim.fn.isdirectory(path) == 0 then
+        vim.notify('wt: Verzeichnis fehlt: ' .. path .. '  (git worktree prune?)', vim.log.levels.WARN)
+        return
+      end
       vim.cmd 'tabnew'
-      vim.cmd('tcd ' .. vim.fn.fnameescape(path))
+      local ok, err = pcall(vim.cmd, 'tcd ' .. vim.fn.fnameescape(path))
+      if not ok then
+        vim.cmd 'tabclose'
+        vim.notify('wt: tcd fehlgeschlagen: ' .. tostring(err), vim.log.levels.ERROR)
+        return
+      end
       vim.cmd 'edit .'
     end
 
@@ -138,20 +149,40 @@ return {
         return
       end
 
-      local items, cur = {}, nil
+      local all, cur = {}, nil
       for _, line in ipairs(out) do
         local p = line:match '^worktree (.+)$'
         if p then
           cur = { path = p }
-          table.insert(items, cur)
+          table.insert(all, cur)
         elseif cur then
           local b = line:match '^branch refs/heads/(.+)$'
           if b then
             cur.branch = b
           elseif line == 'detached' then
             cur.branch = '(detached)'
+          elseif line:match '^prunable' then
+            cur.prunable = true
           end
         end
+      end
+
+      -- git listet Worktrees weiter, deren Verzeichnis weg ist (bis `git worktree prune`).
+      -- Solche anzubieten hiess: Auswahl -> :tcd -> E344. Also raus, und einmal sagen warum.
+      local items, skipped = {}, 0
+      for _, it in ipairs(all) do
+        if it.prunable or vim.fn.isdirectory(it.path) == 0 then
+          skipped = skipped + 1
+        else
+          table.insert(items, it)
+        end
+      end
+      if skipped > 0 then
+        vim.notify(string.format('wt: %d verwaiste Worktree(s) uebersprungen -- git worktree prune', skipped), vim.log.levels.WARN)
+      end
+      if #items == 0 then
+        vim.notify('wt: keine nutzbaren Worktrees', vim.log.levels.WARN)
+        return
       end
 
       for _, it in ipairs(items) do


### PR DESCRIPTION
## Symptom (first real use)

```
E5108: Lua: ... Vim(tcd):E344: Can't find directory ".../scratchpad/wt-vmfix-main" in cdpath
  telescope.lua:130: in function 'goto_worktree'
```

## Cause

`git worktree list --porcelain` keeps listing worktrees whose directory is gone until `git worktree prune` runs — verified, git marks them `prunable gitdir file points to non-existent location`. The picker offered such an entry, `:tcd` failed, and because `tabnew` had already run it also left an empty tab behind.

Fittingly, the dead entry was a leftover scratchpad worktree of mine — the exact failure mode that motivated moving worktrees to a sibling directory in #105.

## Fix

- entries marked `prunable`, or whose directory does not exist, are filtered out of the list
- if any were skipped, one warning says how many and hints at `git worktree prune`
- `goto_worktree` checks the directory **before** `tabnew`, so no empty tab is created
- `tcd` runs under `pcall`; on failure the tab is closed again and the error is reported instead of thrown
- if nothing usable remains, it says so rather than opening an empty picker

## Tested against a real orphaned worktree

```
listed=3  usable=2  skipped=1
  ok: main
  ok: live
goto orphan → rejected (missing), tabs=1     ← no stray tab
goto live   → opened,             tabs=2
```

Closes #122