### PR TITLE
feat(gitlab): wire MR workflow in nvim, make skills forge-aware

### DIFF
--- a/claude/.claude/skills/pr-flow/SKILL.md
+++ b/claude/.claude/skills/pr-flow/SKILL.md
@@ -8,6 +8,27 @@ description: "The issue-to-PR workflow. Use when opening a pull request, startin
 Der verbindliche Ablauf von „Idee" bis „PR offen". Gilt projektübergreifend, nicht
 nur bei Repos mit explizitem Issue-Workflow.
 
+## 0. Erst die Forge bestimmen
+
+Nicht `gh` annehmen — am Remote ablesen:
+
+```bash
+git -C <repo> remote get-url origin   # github.com -> gh, sonst GitLab -> glab
+```
+
+Die Schritte unten sind identisch, nur das CLI wechselt. Kommandos gegen
+`glab --help` geprueft (1.115.x):
+
+| Zweck | GitHub | GitLab |
+|---|---|---|
+| Issue anlegen | `gh issue create --title T --body-file -` | `glab issue create -t T --description-file -` |
+| Label setzen | `gh issue edit N --add-label L` | `glab issue update N --label L` |
+| PR/MR anlegen | `gh pr create --base Z --title T` | `glab mr create --target-branch Z -t T --description-file -` |
+| ansehen | `gh pr view N` | `glab mr view N -F json` |
+
+`glab` braucht bei einer Firmen-Instanz `--repo <gruppe>/<projekt>` oder ein
+konfiguriertes Remote; die Instanz kommt aus `glab auth login --hostname <host>`.
+
 ## 1. Immer ein Issue vor dem PR
 
 Vor jedem PR ein GitHub-Issue aufmachen — auch für kleine Changes.

--- a/claude/.claude/skills/pr-review/SKILL.md
+++ b/claude/.claude/skills/pr-review/SKILL.md
@@ -13,11 +13,17 @@ Workflow `pr-review-deep` nutzen: `Workflow(name: "pr-review-deep", args: "<PR-N
 
 Das Verdikt muss aufs Merge-Gate (CODEOWNERS / required review) zählen.
 
-| Verdikt | Aktion |
-|---|---|
-| APPROVE | `gh pr review <N> --approve` (NICHT nur `--comment`) |
-| COMMENT | `gh pr review <N> --comment` |
-| REQUEST_CHANGES | `gh pr review <N> --request-changes` |
+| Verdikt | GitHub | GitLab |
+|---|---|---|
+| APPROVE | `gh pr review <N> --approve` (NICHT nur `--comment`) | `glab mr approve <N>` |
+| COMMENT | `gh pr review <N> --comment` | `glab mr note create <N> -m "..."` |
+| REQUEST_CHANGES | `gh pr review <N> --request-changes` | **gibt es nicht** — Kommentar, und ein frueheres Approve mit `glab mr revoke <N>` zuruecknehmen |
+
+**GitLab kennt kein request-changes.** `glab mr` bietet nur `approve`/`revoke`. Das
+Verdikt „Aenderungen noetig" ist dort also eine Notiz plus ggf. ein Revoke — beim
+Berichten nicht so tun, als waere es dasselbe formale Gate wie bei GitHub.
+Kommandos gegen `glab --help` (1.115.x) geprueft; `glab mr note -m` ist deprecated,
+korrekt ist `glab mr note create`.
 
 **Ausnahme eigene PRs:** GitHub blockt Self-Approve mit HTTP 422 → dort `--comment`
 verwenden (der formale Approve kommt von einem anderen Reviewer).
@@ -41,7 +47,7 @@ und sich nichts geändert hat — das ist nur Notification-Rauschen.
 Fehler ist das *Vergessen*, nicht das Zuviel: ein Push, der ein `CHANGES_REQUESTED`
 adressiert, hebt das Verdikt NICHT auf — GitHub lässt das alte `CHANGES_REQUESTED` **stale**
 stehen, der PR sieht blockiert aus, obwohl er fertig ist. Also: Findings gefixt + gepusht →
-sofort `gh pr edit <N> --add-reviewer <login>` + kurzer Kommentar, was adressiert wurde. Gilt
+sofort `gh pr edit <N> --add-reviewer <login>` / `glab mr update <N> --reviewer <user>` + kurzer Kommentar, was adressiert wurde. Gilt
 auch, wenn jemand anderes (z. B. eine Parallel-Session) den Fix gepusht hat: wer den Stale-
 Zustand bemerkt, re-requestet. (Beobachtet 2026-07: mehrere PRs — dennisboege-Seed, beide
 docs-ADRs — sahen blockiert aus, weil der Fix längst gepusht, aber nie re-requestet war.)
@@ -50,6 +56,8 @@ Vorm Taggen prüfen:
 
 ```bash
 gh pr view <N> --json reviewRequests,reviews
+# GitLab:
+glab mr view <N> -F json --jq '.reviewers'
 ```
 
 ## Review-Inhalt

--- a/nvim/.config/nvim/lua/plugins/tools/gitlab-review.lua
+++ b/nvim/.config/nvim/lua/plugins/tools/gitlab-review.lua
@@ -20,10 +20,38 @@ return {
       },
     }
 
+    -- <leader>rn gehoert LSP-Rename, deshalb hier ausgespart.
+    -- Funktionsnamen gegen die installierte Version geprueft (lua/gitlab/init.lua).
     local wk = require 'which-key'
     wk.add {
-      { '<leader>r', group = 'Review' },
-      { '<leader>rx', gitlab.choose_merge_request, desc = 'Switch Merge Request' },
+      { '<leader>r', group = 'Review (GitLab MR)' },
+
+      -- MR waehlen und ansehen
+      { '<leader>rx', gitlab.choose_merge_request, desc = 'MR auswaehlen' },
+      { '<leader>rs', gitlab.summary, desc = 'MR-Beschreibung' },
+      { '<leader>rb', gitlab.open_in_browser, desc = 'MR im Browser' },
+
+      -- Review: Diff-Ansicht auf/zu, Diskussionen daneben
+      { '<leader>rr', gitlab.review, desc = 'Review starten' },
+      { '<leader>rq', gitlab.close_review, desc = 'Review schliessen' },
+      { '<leader>rd', gitlab.toggle_discussions, desc = 'Diskussionen ein/aus' },
+
+      -- Kommentieren; visuell ausgewaehlte Zeilen werden zum Multiline-Kommentar
+      { '<leader>rc', gitlab.create_comment, desc = 'Kommentar' },
+      { '<leader>rc', gitlab.create_multiline_comment, desc = 'Kommentar (Auswahl)', mode = 'v' },
+      { '<leader>ri', gitlab.create_comment_suggestion, desc = 'Suggestion (Auswahl)', mode = 'v' },
+
+      -- Drafts: mehrere Anmerkungen sammeln, dann gemeinsam veroeffentlichen
+      { '<leader>rD', gitlab.toggle_draft_mode, desc = 'Draft-Modus' },
+      { '<leader>rp', gitlab.publish_all_drafts, desc = 'Drafts veroeffentlichen' },
+
+      -- Verdikt. GitLab kennt kein request-changes, nur approve/revoke.
+      { '<leader>ra', gitlab.approve, desc = 'Approve' },
+      { '<leader>rA', gitlab.revoke, desc = 'Approve zuruecknehmen' },
+
+      -- Anlegen und Pipeline
+      { '<leader>rM', gitlab.create_mr, desc = 'MR anlegen' },
+      { '<leader>rP', gitlab.pipeline, desc = 'Pipeline' },
     }
   end,
 }


### PR DESCRIPTION
## Starting point

`gitlab.nvim` was already installed and current — with exactly **one** mapping (`<leader>rx`). Everything else the plugin offers was unbound. On the harness side, `pr-flow` and `pr-review` named `gh` exclusively, so in a GitLab repo they would have prescribed the wrong CLI.

## Neovim — the `<leader>r` namespace

Mapped onto the plugin's real API, every name verified against the installed version (15/15 resolve to functions, checked programmatically rather than read off):

| | |
|---|---|
| `rx` choose MR · `rs` summary · `rb` browser | find and read |
| `rr` review · `rq` close review · `rd` discussions | the review surface |
| `rc` comment (visual → multiline) · `ri` suggestion | commenting |
| `rD` draft mode · `rp` publish drafts | batch a review, then publish |
| `ra` approve · `rA` revoke | verdict |
| `rM` create MR · `rP` pipeline | around it |

`<leader>rn` is left to LSP rename.

## Skills — forge-aware, not GitHub-only

`pr-flow` gains a step 0: read the forge off the remote instead of assuming `gh`, with a mapping table. `pr-review`'s verdict table gains a GitLab column.

All `glab` commands verified against `--help` (1.115.x). Two findings worth the check:

- **GitLab has no `request-changes`.** `glab mr` offers `approve`/`revoke` only, so that verdict is a note plus a revoke. The skill says so instead of implying parity — this changes what the merge gate actually means there.
- **`glab mr note -m` is deprecated** — the tool itself points at `glab mr note create`. The top-level `glab mr` examples still show the old form, so copying them would have shipped a deprecated command.

## Not included

Authentication. Neither `glab` (401 against gitlab.com) nor `gitlab.nvim` (`~/.config/gitlab.nvim/` does not exist) is signed in, and credentials are yours to handle. For a company instance: `glab auth login --hostname <host>`, and for the plugin either `$GITLAB_TOKEN` + `$GITLAB_URL` or a `.gitlab.nvim` file — the environment variables keep the token out of a file.

Closes #125