### PR TITLE
feat(nvim): hunk navigation and staging for gitsigns

### DIFF
--- a/nvim/.config/nvim/lua/plugins/core/gitsigns.lua
+++ b/nvim/.config/nvim/lua/plugins/core/gitsigns.lua
@@ -1,9 +1,56 @@
 return {
-  "lewis6991/gitsigns.nvim",
+  'lewis6991/gitsigns.nvim',
   config = function()
-    require("gitsigns").setup()
+    require('gitsigns').setup {
+      -- Maps buffer-lokal, damit sie nur dort existieren wo gitsigns wirklich laeuft
+      on_attach = function(bufnr)
+        local gs = require 'gitsigns'
+        local function map(mode, lhs, rhs, desc)
+          vim.keymap.set(mode, lhs, rhs, { buffer = bufnr, desc = desc })
+        end
 
-    vim.keymap.set("n", "<leader>gp", ":Gitsigns preview_hunk<CR>", {})
-    vim.keymap.set("n", "<leader>gt", ":Gitsigns toggle_current_line_blame<CR>", {})
+        -- Hunk-Navigation. In einem echten Diff behaelt ]c/[c die eingebaute Bedeutung.
+        map('n', ']c', function()
+          if vim.wo.diff then
+            vim.cmd.normal { ']c', bang = true }
+          else
+            gs.nav_hunk 'next'
+          end
+        end, 'Naechster Hunk')
+        map('n', '[c', function()
+          if vim.wo.diff then
+            vim.cmd.normal { '[c', bang = true }
+          else
+            gs.nav_hunk 'prev'
+          end
+        end, 'Voriger Hunk')
+
+        -- Hunk uebernehmen/verwerfen, visuell auf die Auswahl begrenzt
+        map('n', '<leader>ga', gs.stage_hunk, 'Hunk stagen')
+        map('n', '<leader>gr', gs.reset_hunk, 'Hunk verwerfen')
+        map('v', '<leader>ga', function()
+          gs.stage_hunk { vim.fn.line '.', vim.fn.line 'v' }
+        end, 'Auswahl stagen')
+        map('v', '<leader>gr', function()
+          gs.reset_hunk { vim.fn.line '.', vim.fn.line 'v' }
+        end, 'Auswahl verwerfen')
+        map('n', '<leader>gu', gs.undo_stage_hunk, 'Stage ruecknehmen')
+
+        -- ganzer Buffer
+        map('n', '<leader>gA', gs.stage_buffer, 'Buffer stagen')
+        map('n', '<leader>gR', gs.reset_buffer, 'Buffer verwerfen')
+
+        -- ansehen
+        map('n', '<leader>gl', function()
+          gs.blame_line { full = true }
+        end, 'Blame dieser Zeile')
+        map('n', '<leader>gD', function()
+          gs.diffthis '~'
+        end, 'Diff gegen HEAD~')
+      end,
+    }
+
+    vim.keymap.set('n', '<leader>gp', ':Gitsigns preview_hunk<CR>', {})
+    vim.keymap.set('n', '<leader>gt', ':Gitsigns toggle_current_line_blame<CR>', {})
   end,
 }


### PR DESCRIPTION
## Gap

`gitsigns.lua` was 9 lines with two mappings — preview hunk, toggle blame. Missing was what one actually does while reading a diff or an MR. The plugin was already installed; this is configuration, not a new dependency.

## Added (buffer-local via `on_attach`, so they exist only where gitsigns is active)

| | |
|---|---|
| `]c` / `[c` | next / previous hunk — inside a real diff they keep the built-in meaning |
| `<leader>ga` / `<leader>gr` | stage / reset hunk; in visual mode limited to the selection |
| `<leader>gu` | undo stage |
| `<leader>gA` / `<leader>gR` | stage / reset the whole buffer |
| `<leader>gl` | blame this line (full) |
| `<leader>gD` | diff against `HEAD~` |

`<leader>gp` and `<leader>gt` are unchanged. Every key was checked free against the whole config, and every function against the installed version (2026-08-11) — `nav_hunk` is used rather than the deprecated `next_hunk`/`prev_hunk`.

## How far this is verified

Calling the configured `on_attach` directly returns without error and the maps appear (`]c` present afterwards). I could **not** observe the automatic attach finish in a headless run — the async attach chain does not complete there — so the automatic path is argued, not measured: the call site in `gitsigns/attach.lua:378` is unconditional, with no headless or UI guard that would skip it in a real session.

Closes #127