### PR TITLE
feat(cursor): carry the Claude Code harness over to Cursor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,12 @@ node_modules/
 # zellaude plugin-generated files (written into the stowed plugins dir at runtime)
 zellij/.config/zellij/plugins/zellaude-hook.sh
 zellij/.config/zellij/plugins/zellaude.json
+
+# Cursor runtime state — ~/.cursor must be a real dir with individual symlinks
+# (mkdir before stow), but if it ever gets folded into a directory symlink the
+# app would write its live state straight into this public repo.
+cursor/.cursor/cli-config.json
+cursor/.cursor/cli.json
+cursor/.cursor/subagents/
+cursor/.cursor/logs/
+cursor/.cursor/sessions/

--- a/cursor/.cursor/cli-config.seed.json
+++ b/cursor/.cursor/cli-config.seed.json
@@ -1,0 +1,56 @@
+{
+  "version": 1,
+  "editor": {
+    "vimMode": true
+  },
+  "permissions": {
+    "allow": [
+      "Shell(kubectl:get*)",
+      "Shell(kubectl:describe*)",
+      "Shell(kubectl:logs*)",
+      "Shell(kubectl:top*)",
+      "Shell(kubectl:explain*)",
+      "Shell(kubectl:api-resources*)",
+      "Shell(kubectl:version*)",
+      "Shell(kubectl:diff*)",
+      "Shell(kubectl:events*)",
+      "Shell(kubectl:config get-contexts*)",
+      "Shell(kubectl:config current-context)",
+      "Shell(helm:list*)",
+      "Shell(helm:status*)",
+      "Shell(helm:get manifest*)",
+      "Shell(helm:get notes*)",
+      "Shell(helm:get hooks*)",
+      "Shell(helm:get metadata*)",
+      "Shell(helm:history*)",
+      "Shell(helm:show*)",
+      "Shell(helm:search*)",
+      "Shell(helm:template*)",
+      "Shell(helm:lint*)",
+      "Shell(argocd:app get*)",
+      "Shell(argocd:app list*)",
+      "Shell(argocd:app diff*)",
+      "Shell(argocd:app history*)",
+      "Shell(argocd:app resources*)",
+      "Shell(talosctl:get*)",
+      "Shell(talosctl:version*)",
+      "Shell(talosctl:health*)",
+      "Shell(talosctl:config info*)",
+      "Shell(kustomize:build*)",
+      "Shell(kubeconform:*)"
+    ],
+    "deny": [
+      "Shell(kubectl:get secret*)",
+      "Shell(kubectl:get * secret*)",
+      "Shell(kubectl:get -n * secret*)",
+      "Shell(kubectl:get --namespace * secret*)",
+      "Shell(kubectl:get *secrets.v1.*)",
+      "Shell(kubectl:describe secret*)",
+      "Shell(helm:get values*)",
+      "Shell(helm:get all*)",
+      "Read(.env*)",
+      "Read(**/*.key)",
+      "Read(**/*.pem)"
+    ]
+  }
+}

--- a/cursor/.cursor/mcp.json
+++ b/cursor/.cursor/mcp.json
@@ -1,0 +1,39 @@
+{
+  "mcpServers": {
+    "notion-davitec": {
+      "command": "sh",
+      "args": [
+        "-c",
+        "export $(cat \"$HOME/.local/share/opencode/notion-davitec.env\" | xargs) && npx -y @notionhq/notion-mcp-server"
+      ]
+    },
+    "notion-vtrs": {
+      "command": "sh",
+      "args": [
+        "-c",
+        "export $(cat \"$HOME/.local/share/opencode/notion-vtrs.env\" | xargs) && npx -y @notionhq/notion-mcp-server"
+      ]
+    },
+    "notion-secondbrain": {
+      "command": "sh",
+      "args": [
+        "-c",
+        "export $(cat \"$HOME/.local/share/opencode/notion-secondbrain.env\" | xargs) && npx -y @notionhq/notion-mcp-server"
+      ]
+    },
+    "notion-privat": {
+      "command": "sh",
+      "args": [
+        "-c",
+        "export $(cat \"$HOME/.local/share/opencode/notion-privat.env\" | xargs) && npx -y @notionhq/notion-mcp-server"
+      ]
+    },
+    "notion-warhammer": {
+      "command": "sh",
+      "args": [
+        "-c",
+        "export $(cat \"$HOME/.local/share/opencode/notion-warhammer.env\" | xargs) && npx -y @notionhq/notion-mcp-server"
+      ]
+    }
+  }
+}

--- a/cursor/README.md
+++ b/cursor/README.md
@@ -1,0 +1,106 @@
+# cursor
+
+Stow package for the global [Cursor](https://cursor.com) configuration (`~/.cursor`).
+
+Cursor is the agent at a client where Claude Code is not the tool of choice. The
+point of this package is *not* a second harness: most of the Claude Code harness
+is loaded by Cursor as-is. This package only fills the gaps.
+
+## Precondition: the third-party toggle
+
+Everything below marked "reused" depends on one switch:
+
+> Settings → Rules, Skills, Subagents → **Include third-party Plugins, Skills, and other configs**
+
+Without it Cursor ignores the `.claude` directories and the harness is simply not there.
+
+## What Cursor reuses from the `claude` package
+
+| Surface | Path Cursor reads | Notes |
+|---|---|---|
+| Skills | `~/.claude/skills/`, `.claude/skills/` | loaded unmodified next to `~/.cursor/skills/` |
+| Subagents | `~/.claude/agents/`, `.claude/agents/` | `.cursor/` only wins on a name clash |
+| Hooks | `~/.claude/settings.json`, `.claude/settings.json`, `.claude/settings.local.json` | event names are mapped (`PreToolUse` → `preToolUse`, `Stop` → `stop`, …); the nested `hookSpecificOutput` format and exit code 2 both work, so `worktree-guard`, `context-guard` and `macos-notify` run unchanged |
+| Project memory | `CLAUDE.md` / `AGENTS.md` in the repo | picked up per project, no configuration |
+
+## What this package adds
+
+| File | Purpose |
+|---|---|
+| `~/.cursor/cli-config.seed.json` | bootstrap seed for `cli-config.json` — the ported permission allow/deny lists |
+| `~/.cursor/mcp.json` | MCP servers, token-free (see below) |
+| `~/bin/agents-md` (from the `zsh` package) | renders `~/.claude/CLAUDE.md` into a project `AGENTS.md` |
+
+### cli-config.json is app-managed, not stowed
+
+Same reasoning as `settings.json` in the `claude` package: Cursor writes state
+into `~/.cursor/cli-config.json` itself (`hasChangedDefaultModel`, `rewind`,
+model choice, …), so a stow symlink would be replaced on first write and a stale
+repo copy would only mislead. The repo carries the seed instead:
+
+```sh
+cp ~/.cursor/cli-config.seed.json ~/.cursor/cli-config.json
+```
+
+After deliberate permission changes, fold them back into the seed.
+
+### Permissions
+
+Ported from `claude/.claude/settings.seed.json` into Cursor's token syntax:
+`Shell(commandBase:args)` with glob support, and deny always beats allow. The
+read-only kubectl/helm/argocd/talosctl verbs stay allowed; the secret reads
+(`kubectl get secret*`, `helm get values`/`all`) stay denied, plus `Read()`
+denies for `.env*`, `*.key` and `*.pem`, which the Claude list cannot express
+because it only gates shell commands.
+
+Project-level overrides go into `<project>/.cursor/cli.json` — that is the only
+part of the CLI config Cursor reads per project.
+
+### MCP without secrets
+
+`mcp.json` is checked into this **public** repo, so it carries no tokens: each
+server sources its credentials from an env file under
+`$HOME/.local/share/opencode/` at start-up, the same files the Claude Code and
+opencode setups already use. Missing env file = that server fails to start, and
+nothing leaks either way.
+
+The global list is the personal one. On a client machine, scope anything
+client-specific to `<project>/.cursor/mcp.json` instead of adding it here.
+
+## Global conventions: `agents-md`
+
+Cursor has no global `~/.cursor/AGENTS.md`; cross-project instructions would
+have to live in account-synced User Rules, outside of git. So the conventions
+stay in `~/.claude/CLAUDE.md` and get rendered into the project:
+
+```sh
+cd <project> && agents-md
+```
+
+The command rewrites only its own marked block, so hand-written project content
+in `AGENTS.md` survives a re-run. It warns when `AGENTS.md` is not git-ignored —
+these are personal conventions, and whether a client repo should carry them is a
+deliberate decision, not a default.
+
+## What does not carry over
+
+- **Workflows** (`~/.claude/workflows/*.js`) — Cursor has no deterministic
+  workflow runner. The subagents they orchestrate exist, so the same work has to
+  be driven in natural language ("use the team-red subagent, then …").
+- **Statusline, TUI and voice settings** — Claude Code specifics with no counterpart.
+
+## Installation / stow
+
+`~/.cursor` must exist as a **real directory** before stowing. Otherwise stow
+folds the whole package into a single directory symlink, and Cursor then writes
+its live state (`cli-config.json`, sessions, subagent output) straight into this
+public repo — the same trap `~/.config/nvim` already sits in with `lazy-lock.json`.
+
+```sh
+mkdir -p ~/.cursor          # first, so stow links individual files
+cd ~/dotfiles
+stow -t ~ cursor
+cp ~/.cursor/cli-config.seed.json ~/.cursor/cli-config.json   # once per machine
+```
+
+`.gitignore` carries the app-written paths as a second line of defence.

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -12,11 +12,13 @@ tasks:
       - stow lazygit
       - stow ghostty
       - stow claude
+      - stow cursor
 
   check:
-    desc: validate claude config (JSON + shell syntax)
+    desc: validate claude + cursor config (JSON + shell syntax)
     cmds:
       - jq -e . claude/.claude/settings.seed.json >/dev/null
+      - for f in cursor/.cursor/*.json; do jq -e . "$f" >/dev/null; done
       - for f in claude/.claude/hooks/*.sh claude/.claude/statusline-command.sh zsh/bin/*; do if [ -f "$f" ]; then bash -n "$f"; fi; done
       - if command -v shellcheck >/dev/null; then for f in claude/.claude/hooks/*.sh claude/.claude/statusline-command.sh zsh/bin/*; do if [ -f "$f" ]; then shellcheck "$f"; fi; done; fi
 

--- a/zsh/bin/agents-md
+++ b/zsh/bin/agents-md
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# agents-md — render the global Claude Code conventions into a project AGENTS.md.
+#
+# Cursor reads CLAUDE.md/AGENTS.md per project but has no global equivalent of
+# ~/.claude/CLAUDE.md (cross-project instructions live in account-synced User
+# Rules there). This renders the one source of truth into the project instead,
+# so Cursor and Claude Code stay driven by the same conventions.
+#
+# Idempotent: only the marked block is rewritten, hand-written content around it
+# survives. Never touches the file unless the render succeeded.
+#
+# Usage: agents-md [project-dir]   (default: current directory)
+
+set -euo pipefail
+
+BEGIN_MARK='<!-- BEGIN agents-md: global conventions, generated -->'
+END_MARK='<!-- END agents-md -->'
+
+source="${CLAUDE_MEMORY:-$HOME/.claude/CLAUDE.md}"
+target_dir="${1:-$PWD}"
+
+[ -f "$source" ] || { echo "agents-md: no source at $source" >&2; exit 1; }
+[ -d "$target_dir" ] || { echo "agents-md: no such directory: $target_dir" >&2; exit 2; }
+
+target="$target_dir/AGENTS.md"
+tmp=$(mktemp "${TMPDIR:-/tmp}/agents-md.XXXXXX")
+trap 'rm -f "$tmp"' EXIT
+
+{
+  printf '%s\n' "$BEGIN_MARK"
+  printf '<!-- Regenerate with `agents-md`. Edits inside this block are lost. -->\n\n'
+  cat "$source"
+  printf '\n%s\n' "$END_MARK"
+} > "$tmp"
+
+if [ -f "$target" ] && grep -qF "$BEGIN_MARK" "$target"; then
+  # Replace the existing block in place, keep everything around it.
+  merged=$(mktemp "${TMPDIR:-/tmp}/agents-md.XXXXXX")
+  awk -v begin="$BEGIN_MARK" -v end="$END_MARK" -v block="$tmp" '
+    index($0, begin) == 1 { while ((getline line < block) > 0) print line; skip = 1; next }
+    index($0, end) == 1   { skip = 0; next }
+    !skip
+  ' "$target" > "$merged"
+  mv "$merged" "$target"
+  echo "agents-md: refreshed block in $target"
+elif [ -f "$target" ]; then
+  # Hand-written AGENTS.md without our block: append, never overwrite.
+  printf '\n' >> "$target"
+  cat "$tmp" >> "$target"
+  echo "agents-md: appended block to existing $target"
+else
+  cp "$tmp" "$target"
+  echo "agents-md: created $target"
+fi
+
+if ! git -C "$target_dir" check-ignore -q AGENTS.md 2>/dev/null; then
+  echo "agents-md: note — AGENTS.md is not git-ignored here; these are personal conventions, decide before committing them" >&2
+fi


### PR DESCRIPTION
Closes #129

## What

A stow package for `~/.cursor` that reuses the existing harness instead of duplicating it, plus a generator for the one thing Cursor cannot reuse.

## Why so small

Verified against the Cursor docs: with *Settings → Rules, Skills, Subagents → Include third-party Plugins, Skills, and other configs* enabled, Cursor loads the `.claude` directories directly:

- **20 skills** from `~/.claude/skills/` — unmodified
- **18 subagents** from `~/.claude/agents/` — unmodified, `.cursor/` only wins on a name clash
- **hooks** from `~/.claude/settings.json` — event names mapped (`PreToolUse` → `preToolUse`, `Stop` → `stop`), `hookSpecificOutput` and exit code 2 understood, so `worktree-guard`, `context-guard` and `macos-notify` run as they are

That leaves three gaps, which this PR fills.

## Changes

- `cursor/.cursor/cli-config.seed.json` — permissions ported into Cursor's token syntax (`Shell(commandBase:args)` with globs, deny beats allow). Read-only kubectl/helm/argocd/talosctl verbs stay allowed, the secret reads stay denied, plus `Read()` denies for `.env*`/`*.key`/`*.pem` that the Claude list cannot express because it only gates shell commands.
- `cursor/.cursor/mcp.json` — the five Notion servers, sourcing credentials from the existing env files at start-up. No token enters this public repo.
- `zsh/bin/agents-md` — renders `~/.claude/CLAUDE.md` into a project `AGENTS.md`. Cursor reads CLAUDE.md/AGENTS.md per project but has no global equivalent, and User Rules live outside git. Idempotent: rewrites only its marked block, warns when `AGENTS.md` is not git-ignored.
- `.gitignore` + README bootstrap — `~/.cursor` has to exist as a real directory before stowing, otherwise stow folds it into a directory symlink and Cursor writes its live state into this repo (the trap `~/.config/nvim` already sits in).
- `taskfile.yml` — `stow cursor` in setup, JSON validation in `check`.

## Not carried over, deliberately

- **Workflows** (`~/.claude/workflows/*.js`) — Cursor has no deterministic runner. The subagents they orchestrate do exist, so the same work has to be driven in natural language.
- Statusline, TUI and voice settings — Claude Code specifics.

## Verification

- `task check` green (shellcheck is not installed on this machine, so that step self-skipped)
- `agents-md` exercised end to end in a scratch repo: creates the file, refreshes the block on re-run, leaves hand-written sections intact
- `stow -n` dry-run — which is what surfaced the directory-folding trap
- **Not verified:** the Cursor side itself. Neither Cursor.app nor `cursor-agent` is installed on this machine, so the compatibility claims rest on the docs, not on a live run. Worth confirming on the client machine before relying on the deny list.