### PR TITLE
fix(nvim): pick minuet's backend per machine

### DIFF
--- a/nvim/.config/nvim/lua/plugins/ai/minuet.lua
+++ b/nvim/.config/nvim/lua/plugins/ai/minuet.lua
@@ -12,6 +12,28 @@ return {
     end
     local RAG_Context_Window_Size = 8000
 
+    -- Zwei Rechner, zwei lokale Backends: LM Studio auf dem Mac, Ollama auf der
+    -- Linux-Workstation. Vorher stand hier fest der LM-Studio-Endpoint, auf Linux
+    -- lief die Completion damit still ins Leere -- ohne Fehler, einfach ohne
+    -- Vorschlaege.
+    --
+    -- FIM braucht die -base-Modelle: die -instruct-Varianten sind auf Chat
+    -- getrimmt, und qwen3-coder hat gar keine base-Variante und faengt bei 30B an.
+    -- 7b-base (4.7 GB) passt in 8 GB VRAM; bei mehr auf 14b-base (9.0 GB), ohne
+    -- dedizierte GPU auf 3b-base (1.9 GB) -- Ghost-Text lebt von Latenz, nicht
+    -- von Parametern. Vorher `ollama pull qwen2.5-coder:7b-base`.
+    local backend = vim.fn.has 'mac' == 1
+        and {
+          name = 'LM Studio Local',
+          end_point = 'http://localhost:1234/v1/completions',
+          model = 'jolovicdev/qwen2.5-coder-1.5b-lf-fim-heavy',
+        }
+      or {
+        name = 'Ollama Local',
+        end_point = 'http://localhost:11434/v1/completions',
+        model = 'qwen2.5-coder:7b-base',
+      }
+
     local rag_ignore_ft = { 'yaml', 'json', 'toml', 'terraform', 'hcl', 'helm' }
 
     require('minuet').setup {
@@ -24,11 +46,11 @@ return {
       context_window = 1024,
       provider_options = {
         openai_fim_compatible = {
-          model = 'jolovicdev/qwen2.5-coder-1.5b-lf-fim-heavy',
-          end_point = 'http://localhost:1234/v1/completions',
+          model = backend.model,
+          end_point = backend.end_point,
           stream = false,
           api_key = 'TERM',
-          name = 'LM Studio Local',
+          name = backend.name,
           template = {
             prompt = function(pref, suff, _)
               local prompt_message = ''


### PR DESCRIPTION
Closes #135

## What

minuet's endpoint was hardcoded to `http://localhost:1234` (LM Studio). That is the Mac. On the Linux workstation nothing listens there, so completion produced nothing — and silently, because there is no backend to return an error.

Now: LM Studio on macOS exactly as before, Ollama (`11434`) on Linux.

## Model choice

`qwen2.5-coder:7b-base`, and the `-base` part is the point:

- the `-instruct` variants are chat-tuned; the `-base` tags are the ones meant for fill-in-the-middle
- `qwen3-coder` has **no** base variant and starts at 30B / 19GB — unusable for tab completion regardless of hardware

Scaling is one line, documented in the config: `14b-base` (9.0 GB) with more VRAM, `3b-base` (1.9 GB) without a dedicated GPU. Ghost-text lives on latency, not on parameter count — a big model on CPU is worse than a small one on GPU, because a suggestion that arrives after the next keystroke is worse than none.

Prerequisite on the Linux box: `ollama pull qwen2.5-coder:7b-base`.

## Verification

- Lua syntax loads, `stylua --check` clean against the project config
- The `vim.fn.has 'mac' == 1` precedence verified in a live nvim, not assumed: it resolves to LM Studio here
- **Not verified:** the Ollama path itself. I have no access to the Linux machine, and its GPU is still unknown — if it has little or no VRAM, drop to `3b-base` before judging the result.

## Left alone deliberately

VectorCode still feeds RAG context into every completion request. With a 7B model that context probably no longer earns its latency, but that is a separate question from "no backend at all", and it affects the Mac too — worth a follow-up once the new model is actually running.