### PR TITLE
feat(nvim): run CodeCompanion's chat on Ollama where no agent CLI exists

### DIFF
--- a/nvim/.config/nvim/lua/plugins/ai/codecompanion.lua
+++ b/nvim/.config/nvim/lua/plugins/ai/codecompanion.lua
@@ -18,6 +18,20 @@ return {
     end
   end,
   opts = {
+    adapters = {
+      http = {
+        extend = {
+          ollama = {
+            -- Muss gepinnt werden: auf der Linux-Kiste liegt fuers FIM ein
+            -- -base-Modell, und das wuerde im Chat Unsinn produzieren. Chat
+            -- braucht die instruct-Variante. Auf CPU ist 7b zaeh, aber beim
+            -- Chat wartet man auf eine Antwort -- anders als beim Ghost-Text.
+            -- Zu langsam? Dann qwen2.5-coder:3b. Vorher `ollama pull`.
+            schema = { model = { default = 'qwen2.5-coder:7b' } },
+          },
+        },
+      },
+    },
     interactions = {
       chat = {
         -- claude_code und cursor_cli sind mitgelieferte ACP-Presets: der Agent
@@ -26,9 +40,15 @@ return {
         -- Tabelle wuerde die Preset-Aufloesung ersetzen und den Chat brechen;
         -- Abweichungen gehoeren nach adapters.acp.extend.
         --
-        -- Default ist der Agent dieses Rechners. Auf einem Cursor-Rechner per
-        -- <leader>ac oder `ga` im Chat-Buffer auf cursor_cli wechseln.
-        adapter = 'claude_code',
+        -- Default ist, was der jeweilige Rechner hat: auf dem Mac Claude Code
+        -- ueber ACP, auf der Linux-Workstation vorerst Ollama ueber HTTP --
+        -- dort gibt es weder Claude Code noch (bis auf Weiteres) Cursor.
+        --
+        -- Uebergangsloesung mit Ansage: ein kleines lokales Modell auf CPU
+        -- taugt fuer Fragen und Erklaerungen, agentisches Arbeiten mit Tools
+        -- kann es kaum. Sobald Cursor da ist, wird aus dem 'ollama' hier ein
+        -- 'cursor_cli' -- der Rest der Konfiguration bleibt.
+        adapter = vim.fn.has 'mac' == 1 and 'claude_code' or 'ollama',
       },
       opts = {
         -- Der Agent schreibt Dateien selbst; ohne Watcher zeigt nvim weiter den


### PR DESCRIPTION
Closes #139

## What

The chat adapter was `claude_code` unconditionally. On the Linux workstation that is a backend that does not exist, and Cursor is about three weeks away — so the chat was dead there.

```lua
adapter = vim.fn.has 'mac' == 1 and 'claude_code' or 'ollama',
```

Mac keeps Claude Code over ACP, Linux talks to Ollama over HTTP on `11434` (the adapter honours `OLLAMA_HOST`). When Cursor lands, `'ollama'` becomes `'cursor_cli'` and nothing else changes.

## Why the model is pinned

`qwen2.5-coder:7b` — the instruct variant, deliberately:

- that machine currently carries `qwen2.5-coder:1.5b-base` for minuet's FIM, and a base model in a chat produces nonsense, since it completes text rather than answering
- without a pin, the adapter picks from whatever Ollama reports, which is exactly that base model today

Prerequisite: `ollama pull qwen2.5-coder:7b`. If it feels too slow on CPU, `3b` is the documented fallback — for chat the trade-off differs from ghost-text, because here you are waiting for an answer rather than being interrupted by one.

## Expectations, stated plainly

This is a stopgap, not a replacement for the agent. A small local model on CPU handles questions and explanations; tool use and agentic editing are weak, so the diff workflow (`gv`/`g2`/`g3`) will rarely come into play until Cursor is there.

## Verification

- The plugin spec evaluates and `stylua --check` is clean
- The override path is confirmed in the plugin source: `config.adapters.http.extend` is applied via `shared.apply_extend` in `adapters/http/init.lua`
- **Not verified on the target machine:** no Ollama on this Mac and no access to the Linux box, so whether the pinned model actually resolves there is something the first chat will show — the adapter name and model appear in the chat buffer header.