### PR TITLE
feat(nvim): render the CodeCompanion chat and show context usage

### DIFF
--- a/nvim/.config/nvim/lua/plugins/ai/codecompanion.lua
+++ b/nvim/.config/nvim/lua/plugins/ai/codecompanion.lua
@@ -27,7 +27,14 @@ return {
             -- braucht die instruct-Variante. Auf CPU ist 7b zaeh, aber beim
             -- Chat wartet man auf eine Antwort -- anders als beim Ghost-Text.
             -- Zu langsam? Dann qwen2.5-coder:3b. Vorher `ollama pull`.
-            schema = { model = { default = 'qwen2.5-coder:7b' } },
+            schema = {
+              model = { default = 'qwen2.5-coder:7b' },
+              -- Ollamas num_ctx ist per Default nil, das Fenster damit
+              -- unbekannt -- ohne Zahl gibt es auch keine Auslastung. Explizit
+              -- gesetzt dient es beidem: der Anzeige unten und der CPU, der ein
+              -- grosses Fenster teuer zu stehen kommt.
+              num_ctx = { default = 8192 },
+            },
           },
         },
       },
@@ -58,6 +65,18 @@ return {
     },
     display = {
       action_palette = { provider = 'telescope' },
+      chat = {
+        -- Kontextauslastung statt blanker Tokenzahl -- wie im Claude CLI.
+        -- Nur HTTP-Adapter (hier Ollama) liefern Zaehlwerte; ueber ACP kommt
+        -- keine Usage, dort bleibt die Anzeige leer.
+        token_count = function(tokens, adapter)
+          local window = adapter and adapter.schema and adapter.schema.num_ctx and adapter.schema.num_ctx.default
+          if type(window) ~= 'number' or window <= 0 then
+            return string.format(' (%d tokens)', tokens)
+          end
+          return string.format(' (%.1fk/%.0fk · %d%%)', tokens / 1000, window / 1000, math.floor(tokens / window * 100))
+        end,
+      },
       -- Aenderungen des Agenten landen als Diff im Buffer: ansehen mit gv,
       -- annehmen mit g2, verwerfen mit g3, alles im Buffer akzeptieren mit g1.
       -- threshold_for_chat bleibt beim Default (6) -- kleine Diffs stehen im

--- a/nvim/.config/nvim/lua/plugins/ai/codecompanion.lua
+++ b/nvim/.config/nvim/lua/plugins/ai/codecompanion.lua
@@ -41,6 +41,17 @@ return {
     },
     interactions = {
       chat = {
+        -- Sprechende Header statt 'Me' und 'CodeCompanion (Ollama)': auf einen
+        -- Blick sichtbar, wer antwortet -- und mit welchem Modell. Den
+        -- Modellnamen gibt es nur bei HTTP-Adaptern; ueber ACP ist
+        -- adapter.model nil, dann bleibt es beim Adapternamen.
+        roles = {
+          user = 'Robert',
+          llm = function(adapter)
+            local model = adapter.model and (adapter.model.formatted_name or adapter.model.name)
+            return adapter.formatted_name .. (model and (' · ' .. model) or '')
+          end,
+        },
         -- claude_code und cursor_cli sind mitgelieferte ACP-Presets: der Agent
         -- laeuft als CLI mit eigenem Tool-Zugriff aufs Repo, kein API-Key -- es
         -- zaehlt das Abo des jeweiligen Rechners. Eine eigene adapters.acp-

--- a/nvim/.config/nvim/lua/plugins/coding-languages/markdown.lua
+++ b/nvim/.config/nvim/lua/plugins/coding-languages/markdown.lua
@@ -5,5 +5,11 @@ return {
   -- dependencies = { 'nvim-treesitter/nvim-treesitter', 'nvim-tree/nvim-web-devicons' }, -- if you prefer nvim-web-devicons
   ---@module 'render-markdown'
   ---@type render.md.UserConfig
-  opts = {},
+  opts = {
+    -- Der CodeCompanion-Chat ist Markdown, hat aber den Filetype 'codecompanion'
+    -- und lief deshalb ungerendert durch: Rollen-Header als rohe ##-Zeilen,
+    -- Codebloecke als Backticks. Mit aufgenommen trennt der Renderer Frage und
+    -- Antwort sichtbar. Markdown-Dateien selbst aendern sich dadurch nicht.
+    file_types = { 'markdown', 'codecompanion' },
+  },
 }


### PR DESCRIPTION
Closes #141

## Readability

`render-markdown.nvim` was already installed but ran with `opts = {}`, which means `file_types = { 'markdown' }`. The chat buffer has the filetype `codecompanion`, so it never got rendered — that is why prompts and answers ran together as raw `##` headers and backticks. Adding the filetype is the whole fix; markdown files are untouched, and the plugin's load behaviour stays as it was.

## Context usage

`display.chat.token_count` now reports the share of the context window instead of a bare number:

```
 (1.2k/8k · 15%)      →  Ollama, window known
 (1234 tokens)        →  no window available, falls back
```

For that to mean anything the window has to be known, and Ollama's `num_ctx` defaults to `nil`. It is now pinned to 8192, which serves two purposes: the percentage has a denominator, and the window stays small enough that CPU inference does not suffer — a large context is expensive to process there.

**Where this will be empty:** the `claude_code` ACP adapter carries no token or usage handling at all (nothing in its source references either), so on the Mac the counter has nothing to show. Over ACP the agent reports no usage back to CodeCompanion. The fallback keeps that case from breaking, but it will not produce Claude-CLI-style numbers there.

## Verification

- The counter is a plain function, so it is tested directly: 1234/8192 → `(1.2k/8k · 15%)`, 7900 → `96%`, 0 → `0%`, and both an adapter without a schema and a `nil` adapter fall back instead of erroring
- `stylua --check` clean on both files
- **Not verified visually:** whether the rendered chat actually looks the way you want. That needs a real UI, and it is a matter of taste anyway — if the concealed markdown bothers you while editing, the alternative is CodeCompanion's own `show_header_separator = true` instead of the renderer.